### PR TITLE
T12 — Inter-bank OTC entiteti + Banka kao klijent fonda + listMy/BankPositions

### DIFF
--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/model/InterbankOtcContract.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/model/InterbankOtcContract.java
@@ -1,0 +1,69 @@
+package rs.raf.banka2_bek.interbank.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/**
+ * Inter-bank OTC opcioni ugovor nakon prihvatanja ponude
+ * (snapshot OptionDescription iz protokola §2.7.2).
+ *
+ * Spec: Celina 5 — opcioni ugovor; protokol §3.6 i §2.7.2.
+ * Povezan je sa InterbankOtcNegotiation (negotiationId u protokolu = ForeignBankId
+ * kod prodavceve banke).
+ */
+@Entity
+@Table(name = "interbank_otc_contracts")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InterbankOtcContract {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "negotiation_id", nullable = false)
+    private InterbankOtcNegotiation negotiation;
+
+    /** Duplikat negotiationId iz ugovora radi brzog upita bez join-a. */
+    @Column(name = "negotiation_routing_number", nullable = false, length = 8)
+    private String negotiationRoutingNumber;
+
+    @Column(name = "negotiation_opaque_id", nullable = false, length = 64)
+    private String negotiationOpaqueId;
+
+    @Column(name = "stock_ticker", nullable = false, length = 32)
+    private String stockTicker;
+
+    @Column(name = "price_per_unit_amount", nullable = false, precision = 19, scale = 4)
+    private BigDecimal pricePerUnitAmount;
+
+    @Column(name = "price_per_unit_currency", nullable = false, length = 8)
+    private String pricePerUnitCurrency;
+
+    @Column(name = "settlement_instant", nullable = false)
+    private Instant settlementInstant;
+
+    @Column(name = "share_amount", nullable = false)
+    private Integer shareAmount;
+
+    @Column(name = "premium_amount", nullable = false, precision = 19, scale = 4)
+    private BigDecimal premiumAmount;
+
+    @Column(name = "premium_currency", nullable = false, length = 8)
+    private String premiumCurrency;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 32)
+    @Builder.Default
+    private InterbankOtcContractStatus status = InterbankOtcContractStatus.ACTIVE;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/model/InterbankOtcContractStatus.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/model/InterbankOtcContractStatus.java
@@ -1,0 +1,8 @@
+package rs.raf.banka2_bek.interbank.model;
+
+public enum InterbankOtcContractStatus {
+    ACTIVE,
+    EXERCISED,
+    EXPIRED,
+    CANCELLED
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/model/InterbankOtcNegotiation.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/model/InterbankOtcNegotiation.java
@@ -1,0 +1,90 @@
+package rs.raf.banka2_bek.interbank.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/**
+ * Lokalni zapis inter-bank OTC pregovora (mirror OtcNegotiation / OtcOffer iz protokola).
+ *
+ * Spec: Celina 5 (Nova) — OTC izmedju banaka; protokol §2.3 (ForeignBankId), §3 (OTC negotiation).
+ * Sve strane su uvek ForeignBankId — par routingNumber + neproziran string
+ * (kolone buyer/seller/lastModifiedBy + sam negotiationId).
+ */
+@Entity
+@Table(
+        name = "interbank_otc_negotiations",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_interbank_negotiation_foreign_id",
+                columnNames = {"negotiation_routing_number", "negotiation_opaque_id"}
+        )
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InterbankOtcNegotiation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** Autoritativni ID pregovora kod banke prodavca (ForeignBankId). */
+    @Column(name = "negotiation_routing_number", nullable = false, length = 8)
+    private String negotiationRoutingNumber;
+
+    @Column(name = "negotiation_opaque_id", nullable = false, length = 64)
+    private String negotiationOpaqueId;
+
+    @Column(name = "stock_ticker", nullable = false, length = 32)
+    private String stockTicker;
+
+    /** ISO-8601 datum/vreme poravnanja, cuva se kao Instant u UTC. */
+    @Column(name = "settlement_instant", nullable = false)
+    private Instant settlementInstant;
+
+    @Column(name = "price_per_unit_amount", nullable = false, precision = 19, scale = 4)
+    private BigDecimal pricePerUnitAmount;
+
+    @Column(name = "price_per_unit_currency", nullable = false, length = 8)
+    private String pricePerUnitCurrency;
+
+    @Column(name = "premium_amount", nullable = false, precision = 19, scale = 4)
+    private BigDecimal premiumAmount;
+
+    @Column(name = "premium_currency", nullable = false, length = 8)
+    private String premiumCurrency;
+
+    @Column(name = "amount", nullable = false)
+    private Integer amount;
+
+    @Column(name = "buyer_routing_number", nullable = false, length = 8)
+    private String buyerRoutingNumber;
+
+    @Column(name = "buyer_opaque_id", nullable = false, length = 64)
+    private String buyerOpaqueId;
+
+    @Column(name = "seller_routing_number", nullable = false, length = 8)
+    private String sellerRoutingNumber;
+
+    @Column(name = "seller_opaque_id", nullable = false, length = 64)
+    private String sellerOpaqueId;
+
+    @Column(name = "last_modified_by_routing_number", nullable = false, length = 8)
+    private String lastModifiedByRoutingNumber;
+
+    @Column(name = "last_modified_by_opaque_id", nullable = false, length = 64)
+    private String lastModifiedByOpaqueId;
+
+    @Column(name = "ongoing", nullable = false)
+    @ColumnDefault("true")
+    @Builder.Default
+    private boolean ongoing = true;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/repository/InterbankOtcContractRepository.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/repository/InterbankOtcContractRepository.java
@@ -1,0 +1,33 @@
+package rs.raf.banka2_bek.interbank.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import rs.raf.banka2_bek.interbank.model.InterbankOtcContract;
+import rs.raf.banka2_bek.interbank.model.InterbankOtcContractStatus;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Repozitorijum inter-bank OTC opcionih ugovora
+ * (snapshot prihvacene ponude — protokol §2.7.2 / §3.6).
+ *
+ * TODO T2 outbound: dodati po potrebi finder metode kad outbound „accept“ formira
+ * ugovor i ceka potvrdu T1 transaction executora:
+ *   - findByStatusAndStockTicker(...) — agregacija po hartiji.
+ *
+ * TODO T3 inbound: dodati po potrebi finder metode za saga / izvrsavanje opcija:
+ *   - findBySettlementInstantBeforeAndStatus(Instant, ACTIVE) — scheduler za isteklost
+ *     opcija (vidi §2.7.2: "if the option was not used, the resources stuck in an
+ *     option shall be un-reserved").
+ */
+public interface InterbankOtcContractRepository extends JpaRepository<InterbankOtcContract, Long> {
+
+    List<InterbankOtcContract> findByNegotiation_Id(Long negotiationId);
+
+    Optional<InterbankOtcContract> findByNegotiationRoutingNumberAndNegotiationOpaqueId(
+            String negotiationRoutingNumber,
+            String negotiationOpaqueId
+    );
+
+    List<InterbankOtcContract> findByStatus(InterbankOtcContractStatus status);
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/repository/InterbankOtcNegotiationRepository.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/repository/InterbankOtcNegotiationRepository.java
@@ -1,0 +1,34 @@
+package rs.raf.banka2_bek.interbank.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import rs.raf.banka2_bek.interbank.model.InterbankOtcNegotiation;
+
+import java.util.Optional;
+
+/**
+ * Repozitorijum inter-bank OTC pregovora.
+ *
+ * T12 izlaze samo lookup po autoritativnom ForeignBankId paru
+ * (negotiationRoutingNumber + negotiationOpaqueId) — to je dovoljno za detekciju
+ * mirror-a vec postojeceg pregovora i za update po PUT /negotiations/{rn}/{id}.
+ *
+ * TODO T2 outbound: dodati custom finder metode po potrebi:
+ *   - findByBuyerRoutingNumberAndBuyerOpaqueId(...) — listanje pregovora za kupca
+ *     (kad mi saljemo ponudu drugoj banci)
+ *   - findByLastModifiedByRoutingNumberAndLastModifiedByOpaqueId(...) — turn check
+ *     pre slanja kontraponude (ne smemo dva puta zaredom)
+ *
+ * TODO T3 inbound: dodati custom finder metode po potrebi:
+ *   - findByOngoingTrue() — aktivni pregovori za scheduler / cleanup
+ *   - findBySellerRoutingNumberAndSellerOpaqueId(...) — listanje pregovora gde smo
+ *     mi prodavac (autoritativna kopija je uvek kod prodavca)
+ *   - findByLastModifiedByRoutingNumberAndLastModifiedByOpaqueId(...) — turn check
+ *     pri inbound PUT (ako je lastModifiedBy = trenutni posiljalac, 409 Conflict)
+ */
+public interface InterbankOtcNegotiationRepository extends JpaRepository<InterbankOtcNegotiation, Long> {
+
+    Optional<InterbankOtcNegotiation> findByNegotiationRoutingNumberAndNegotiationOpaqueId(
+            String negotiationRoutingNumber,
+            String negotiationOpaqueId
+    );
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/service/OtcNegotiationService.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/service/OtcNegotiationService.java
@@ -1,0 +1,52 @@
+package rs.raf.banka2_bek.interbank.service;
+
+import org.springframework.stereotype.Service;
+
+/**
+ * Inter-bank OTC pregovori — outbound i inbound logiku dodaju T2 i T3.
+ *
+ * INTER-BANK OTC NEGOTIATION ENTITETI — sema polja (mapiranje na protokol §3 i §2.3):
+ *
+ * InterbankOtcNegotiation -> tabela interbank_otc_negotiations
+ *   id                                                    : Long, PK
+ *   negotiationRoutingNumber + negotiationOpaqueId        : ForeignBankId autoritativnog
+ *                                                           pregovora (obicno banka prodavca)
+ *   stockTicker                                           : string — StockDescription.ticker
+ *   settlementInstant                                     : Instant (UTC) — ISO-8601 settlementDate
+ *   pricePerUnitAmount + pricePerUnitCurrency             : MonetaryValue pricePerUnit
+ *   premiumAmount + premiumCurrency                       : MonetaryValue premium
+ *   amount                                                : int — broj akcija
+ *   buyerRoutingNumber + buyerOpaqueId                    : buyerId
+ *   sellerRoutingNumber + sellerOpaqueId                  : sellerId
+ *   lastModifiedByRoutingNumber + lastModifiedByOpaqueId  : lastModifiedBy
+ *   ongoing                                               : boolean — protokol isOngoing
+ *   updatedAt                                             : poslednja izmena ponude
+ *
+ * InterbankOtcContract -> tabela interbank_otc_contracts
+ *   id                                                    : Long, PK
+ *   negotiation                                           : FK na InterbankOtcNegotiation
+ *   negotiationRoutingNumber + negotiationOpaqueId        : kopija negotiationId
+ *                                                           (OptionDescription.negotiationId)
+ *   stockTicker, pricePerUnit*, settlementInstant, shareAmount
+ *   premiumAmount + premiumCurrency                       : snapshot u trenutku sklapanja
+ *   status                                                : ACTIVE | EXERCISED | EXPIRED | CANCELLED
+ *   createdAt
+ *
+ * Intra-bank OTC entiteti se ne diraju — ovi zapisi su samo za medjubankarski sloj
+ * sa neprozirnim ID-jevima.
+ */
+@Service
+public class OtcNegotiationService {
+
+    // TODO T2 outbound: outbound metode — slanje OTC poruka drugoj banci
+    //                   (POST /negotiations, PUT /negotiations/{rn}/{id} kontraponuda,
+    //                   DELETE close, GET accept).
+    //                   Injektovati InterbankOtcNegotiationRepository i
+    //                   InterbankOtcContractRepository ovde kada krenete sa
+    //                   implementacijom (preporuceno: @RequiredArgsConstructor).
+    //
+    // TODO T3 inbound: inbound endpoint dispatch — kreiranje pregovora na nasoj strani
+    //                  kao prodavac, validacija turn-a (lastModifiedBy != trenutni
+    //                  posiljalac), close, accept (formira 4-postavku po §3.6 protokola
+    //                  i prosledjuje T1 transaction executoru).
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/investmentfund/dto/ClientFundPositionDto.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/investmentfund/dto/ClientFundPositionDto.java
@@ -1,0 +1,28 @@
+package rs.raf.banka2_bek.investmentfund.dto;
+
+import lombok.Builder;
+
+import java.math.BigDecimal;
+
+/**
+ * Pozicija klijenta u fondu (lista za Moj portfolio / Profit banke).
+ * clientId moze biti i klijent koji predstavlja vlasnika banke
+ * (Napomene 1 i 2 — to moze biti sama banka kao pravno lice).
+ *
+ * managerName i managerLastname se ukljucuju jer ih Profit Banke „Pozicije
+ * u fondovima“ stranica direktno prikazuje (Celina 4 — kolona „ime i prezime
+ * menadzera fonda“).
+ *
+ * Izvedena polja koja Celina 4 trazi za FE prikaz (ProcenatFonda,
+ * TrenutnaVrednostPozicije, Profit) NE puni T12 — popunjava ih T7/T10 sloj
+ * preko FundValueCalculator helper servisa pre vracanja FE-u.
+ */
+@Builder
+public record ClientFundPositionDto(
+        Long fundId,
+        String fundName,
+        String managerName,
+        String managerLastname,
+        Long clientId,
+        BigDecimal totalInvestedAmountRsd
+) {}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/investmentfund/model/ClientFundPosition.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/investmentfund/model/ClientFundPosition.java
@@ -1,0 +1,46 @@
+package rs.raf.banka2_bek.investmentfund.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import rs.raf.banka2_bek.client.model.Client;
+
+import java.math.BigDecimal;
+
+/**
+ * Ukupna pozicija klijenta u investicionom fondu (RSD uloženo).
+ *
+ * Klijent moze biti i sama banka (vlasnik banke se modeluje kao Client po
+ * Napomenama 1 i 2 iz Celine 4) — u tom slucaju red predstavlja bankinu
+ * investiciju u fondu (vidljivu u Profit banke portalu i u supervizorovom
+ * Moj portfolio).
+ */
+@Entity
+@Table(
+        name = "client_fund_positions",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_client_fund",
+                columnNames = {"client_id", "fund_id"}
+        )
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ClientFundPosition {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "client_id", nullable = false)
+    private Client client;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "fund_id", nullable = false)
+    private InvestmentFund fund;
+
+    @Column(name = "total_invested_amount", nullable = false, precision = 19, scale = 4)
+    private BigDecimal totalInvestedAmount;
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/investmentfund/model/InvestmentFund.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/investmentfund/model/InvestmentFund.java
@@ -1,0 +1,73 @@
+package rs.raf.banka2_bek.investmentfund.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import rs.raf.banka2_bek.account.model.Account;
+import rs.raf.banka2_bek.client.model.Client;
+import rs.raf.banka2_bek.employee.model.Employee;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * Investicioni fond — Celina 4, entitet fond.
+ *
+ * ownerClient = klijent koji je vlasnik banke; pod njim se vode bankine pozicije
+ * u fondovima (Napomene 1 i 2 iz Celine 4 — banka kao entitet ima vlasnika
+ * koji je modelovan kao Client, i tu se beleze sve bankine investicije).
+ *
+ * Klijent vlasnik moze biti:
+ *   - sama banka kao pravno lice (po zadatku T12 — „Banka 2 d.o.o.“ se vodi
+ *     kao Client sa email-om bank.owner-client-email), ili
+ *   - bilo koje drugo lice/firma koje je registrovano kao Client i postavljeno
+ *     kao vlasnik banke (kasnije, ako bude potrebno).
+ */
+@Entity
+@Table(name = "investment_funds")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InvestmentFund {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 200)
+    private String name;
+
+    @Column(length = 2000)
+    private String description;
+
+    @Column(name = "minimum_contribution", nullable = false, precision = 19, scale = 4)
+    private BigDecimal minimumContribution;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "manager_id", nullable = false)
+    private Employee manager;
+
+    /** RSD račun fonda (T7). */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "fund_account_id", nullable = false)
+    private Account fundAccount;
+
+    /**
+     * Klijent koji je vlasnik banke (moze biti sama banka kao pravno lice, ili neko
+     * drugo lice/firma vlasnik) — pod njim se vode bankine pozicije u fondu
+     * (Napomene 1 i 2 iz Celine 4).
+     */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "owner_client_id", nullable = false)
+    private Client ownerClient;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    @ColumnDefault("true")
+    @Builder.Default
+    private boolean active = true;
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/investmentfund/repository/ClientFundPositionRepository.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/investmentfund/repository/ClientFundPositionRepository.java
@@ -1,0 +1,25 @@
+package rs.raf.banka2_bek.investmentfund.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import rs.raf.banka2_bek.investmentfund.model.ClientFundPosition;
+
+import java.util.List;
+
+/**
+ * Repozitorijum pozicija klijenata u investicionim fondovima.
+ *
+ * T12 izlaze findByClient_Id — koristi ga InvestmentFundService.listMyPositions
+ * i listBankPositions. Napomena: clientId moze biti i klijent koji predstavlja
+ * vlasnika banke (po Napomenama 1 i 2 to moze biti sama banka kao pravno lice).
+ *
+ * TODO T7 fund details: dodati custom finder metode po potrebi:
+ *   - List&lt;ClientFundPosition&gt; findByFund_Id(Long fundId) — lista ucesnika fonda
+ *
+ * TODO T8 invest / withdraw: dodati custom finder metode po potrebi:
+ *   - Optional&lt;ClientFundPosition&gt; findByClient_IdAndFund_Id(Long clientId, Long fundId)
+ *     — upsert postojece pozicije pri uplati / smanjenje pri isplati
+ */
+public interface ClientFundPositionRepository extends JpaRepository<ClientFundPosition, Long> {
+
+    List<ClientFundPosition> findByClient_Id(Long clientId);
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/investmentfund/repository/InvestmentFundRepository.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/investmentfund/repository/InvestmentFundRepository.java
@@ -1,0 +1,17 @@
+package rs.raf.banka2_bek.investmentfund.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import rs.raf.banka2_bek.investmentfund.model.InvestmentFund;
+
+/**
+ * Repozitorijum investicionih fondova.
+ *
+ * T12 ne zahteva nijednu custom metodu — samo entitet (sa ownerClient) i seed.
+ *
+ * TODO T7 discovery / create / details: dodati custom finder metode po potrebi:
+ *   - List&lt;InvestmentFund&gt; findAllByActiveTrue() — Discovery page
+ *   - List&lt;InvestmentFund&gt; findByManager_Id(Long managerId) — supervizorovi fondovi
+ *   - Optional&lt;InvestmentFund&gt; findByName(String name) — uniqueness check pri kreiranju
+ */
+public interface InvestmentFundRepository extends JpaRepository<InvestmentFund, Long> {
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/investmentfund/service/InvestmentFundService.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/investmentfund/service/InvestmentFundService.java
@@ -1,0 +1,120 @@
+package rs.raf.banka2_bek.investmentfund.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import rs.raf.banka2_bek.auth.model.User;
+import rs.raf.banka2_bek.auth.service.EmployeeUserDetails;
+import rs.raf.banka2_bek.client.repository.ClientRepository;
+import rs.raf.banka2_bek.investmentfund.dto.ClientFundPositionDto;
+import rs.raf.banka2_bek.investmentfund.model.ClientFundPosition;
+import rs.raf.banka2_bek.investmentfund.repository.ClientFundPositionRepository;
+
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * T12 — liste pozicija u investicionim fondovima.
+ * Spec: Celina 4 (Moj portfolio, Napomene 1 i 2) + zadatak T12.
+ *
+ * Konvencija „klijent koji je vlasnik banke“ (po Napomenama 1 i 2):
+ *   bankine investicije se vode kao ClientFundPosition pod posebnim klijentom
+ *   koji predstavlja vlasnika banke. Taj klijent moze biti:
+ *     - sama banka kao pravno lice (T12 seed: „Banka 2 d.o.o.“), ili
+ *     - bilo ko drugi (npr. fizicki osnivac ili druga firma) ko je registrovan
+ *       kao Client i postavljen kao vlasnik banke.
+ *   Email tog klijenta se konfigurise preko bank.owner-client-email.
+ *
+ * Granice ovog servisa: samo listMyPositions i listBankPositions.
+ * Ostale fond metode (createFund, listDiscovery, getFundDetails, invest, withdraw,
+ * performanse, likvidacija) su vlasnistvo T7/T8/T9/T10.
+ */
+@Service
+@RequiredArgsConstructor
+public class InvestmentFundService {
+
+    private final ClientFundPositionRepository clientFundPositionRepository;
+    private final ClientRepository clientRepository;
+
+    @Value("${bank.owner-client-email}")
+    private String bankOwnerClientEmail;
+
+    /**
+     * "Moj portfolio" -> tab "Moji fondovi" (lista pozicija u fondovima).
+     * Pravilo (zadatak T12 + Celina 4 + Napomene 1 i 2):
+     *   - User (klijent)              -> pozicije tog klijenta po njegovom email-u.
+     *                                    Ako se email tog User-a poklapa sa
+     *                                    bank.owner-client-email, vidi bankine
+     *                                    pozicije (legitimno — taj klijent JESTE
+     *                                    vlasnik banke).
+     *   - EmployeeUserDetails (sup.)  -> pozicije klijenta-vlasnika banke
+     *                                    (bank.owner-client-email). Zaposleni nije
+     *                                    Client i nema licne pozicije; po Napomeni 1+2
+     *                                    bankine investicije se vode pod klijentom
+     *                                    vlasnikom (taj klijent moze biti i sama
+     *                                    banka kao pravno lice).
+     *                                    Napomena za FE: po Celini 4 (sekcija „Dodatak
+     *                                    za Moj portfolio“) supervizorov „Moji fondovi“
+     *                                    tab strogo gledano prikazuje fondove kojima
+     *                                    upravlja, NE pozicije. Ali zadataci.txt
+     *                                    eksplicitno kaze da listMyPositions koriste i
+     *                                    supervizori, pa se ovde u T12 poklapamo sa
+     *                                    tom interpretacijom (semantika „moje“ za
+     *                                    supervizora = pozicije institucije koju
+     *                                    reprezentuje). T7 ce dodati zaseban endpoint
+     *                                    za fondove kojima supervizor upravlja
+     *                                    (getManagedFunds ili sl.).
+     *   - Anonimni / neprepoznat      -> prazna lista.
+     */
+    @Transactional(readOnly = true)
+    public List<ClientFundPositionDto> listMyPositions(Authentication authentication) {
+        if (authentication == null || authentication.getPrincipal() == null) {
+            return List.of();
+        }
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof User user) {
+            return findPositionsByClientEmail(user.getEmail());
+        }
+        if (principal instanceof EmployeeUserDetails) {
+            return findPositionsByClientEmail(bankOwnerClientEmail);
+        }
+        return List.of();
+    }
+
+    /**
+     * Pozicije gde je ucesnik klijent koji je vlasnik banke (po Napomeni 2 — taj
+     * klijent moze biti sama banka kao pravno lice ili neko drugo lice/firma vlasnik) —
+     * "Pozicije u fondovima" tab u Profit Banke portalu (Celina 4 + zadatak T12).
+     */
+    @Transactional(readOnly = true)
+    public List<ClientFundPositionDto> listBankPositions() {
+        return findPositionsByClientEmail(bankOwnerClientEmail);
+    }
+
+    private List<ClientFundPositionDto> findPositionsByClientEmail(String email) {
+        if (email == null || email.isBlank()) {
+            return List.of();
+        }
+        return clientRepository
+                .findByEmail(email)
+                .map(client -> clientFundPositionRepository.findByClient_Id(client.getId()).stream()
+                        .map(this::toDto)
+                        .sorted(Comparator.comparing(ClientFundPositionDto::fundName))
+                        .toList())
+                .orElseGet(List::of);
+    }
+
+    private ClientFundPositionDto toDto(ClientFundPosition p) {
+        var manager = p.getFund().getManager();
+        return ClientFundPositionDto.builder()
+                .fundId(p.getFund().getId())
+                .fundName(p.getFund().getName())
+                .managerName(manager == null ? null : manager.getFirstName())
+                .managerLastname(manager == null ? null : manager.getLastName())
+                .clientId(p.getClient().getId())
+                .totalInvestedAmountRsd(p.getTotalInvestedAmount())
+                .build();
+    }
+}

--- a/banka2_bek/src/main/resources/application.properties
+++ b/banka2_bek/src/main/resources/application.properties
@@ -43,6 +43,14 @@ exchange.api.url=https://data.fixer.io/api/latest
 # Bank identification (registration number of the bank's company entity)
 bank.registration-number=22200022
 
+# Email klijenta koji je VLASNIK banke (Celina 4, Napomene 1 i 2).
+# Pod ovim klijentom se vode bankine pozicije u fondovima — koristi ga
+# InvestmentFundService.listBankPositions za "Pozicije u fondovima" tab.
+# Ovaj klijent moze biti i sama banka kao pravno lice (T12 seed: „Banka 2 d.o.o.“),
+# ili neko drugo lice/firma koja je registrovana kao Client i postavljena kao
+# vlasnik banke.
+bank.owner-client-email=banka2.entity@banka2.rs
+
 # OTP configuration
 otp.expiry-minutes=5
 otp.max-attempts=3

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/interbank/repository/InterbankOtcContractRepositoryIT.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/interbank/repository/InterbankOtcContractRepositoryIT.java
@@ -1,0 +1,107 @@
+package rs.raf.banka2_bek.interbank.repository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import rs.raf.banka2_bek.interbank.model.InterbankOtcContract;
+import rs.raf.banka2_bek.interbank.model.InterbankOtcContractStatus;
+import rs.raf.banka2_bek.interbank.model.InterbankOtcNegotiation;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class InterbankOtcContractRepositoryIT {
+
+    @Autowired
+    private InterbankOtcNegotiationRepository negotiationRepository;
+
+    @Autowired
+    private InterbankOtcContractRepository contractRepository;
+
+    private InterbankOtcNegotiation savedNegotiation(String opaqueId) {
+        return negotiationRepository.save(InterbankOtcNegotiation.builder()
+                .negotiationRoutingNumber("333")
+                .negotiationOpaqueId(opaqueId)
+                .stockTicker("MSFT")
+                .settlementInstant(Instant.parse("2025-05-10T00:00:00Z"))
+                .pricePerUnitAmount(new BigDecimal("300.0000"))
+                .pricePerUnitCurrency("USD")
+                .premiumAmount(new BigDecimal("100.0000"))
+                .premiumCurrency("USD")
+                .amount(10)
+                .buyerRoutingNumber("111")
+                .buyerOpaqueId("b")
+                .sellerRoutingNumber("333")
+                .sellerOpaqueId("s")
+                .lastModifiedByRoutingNumber("111")
+                .lastModifiedByOpaqueId("b")
+                .ongoing(false)
+                .updatedAt(Instant.now())
+                .build());
+    }
+
+    private InterbankOtcContract buildContract(InterbankOtcNegotiation nego, InterbankOtcContractStatus status) {
+        return InterbankOtcContract.builder()
+                .negotiation(nego)
+                .negotiationRoutingNumber(nego.getNegotiationRoutingNumber())
+                .negotiationOpaqueId(nego.getNegotiationOpaqueId())
+                .stockTicker(nego.getStockTicker())
+                .pricePerUnitAmount(nego.getPricePerUnitAmount())
+                .pricePerUnitCurrency(nego.getPricePerUnitCurrency())
+                .settlementInstant(nego.getSettlementInstant())
+                .shareAmount(nego.getAmount())
+                .premiumAmount(nego.getPremiumAmount())
+                .premiumCurrency(nego.getPremiumCurrency())
+                .status(status)
+                .createdAt(Instant.now())
+                .build();
+    }
+
+    @Test
+    void saveContractAndFindByNegotiation() {
+        InterbankOtcNegotiation nego = savedNegotiation("n-1");
+        contractRepository.save(buildContract(nego, InterbankOtcContractStatus.ACTIVE));
+
+        List<InterbankOtcContract> byNeg = contractRepository.findByNegotiation_Id(nego.getId());
+        assertThat(byNeg).hasSize(1);
+
+        Optional<InterbankOtcContract> byForeign =
+                contractRepository.findByNegotiationRoutingNumberAndNegotiationOpaqueId("333", "n-1");
+        assertThat(byForeign).isPresent();
+        assertThat(byForeign.get().getStatus()).isEqualTo(InterbankOtcContractStatus.ACTIVE);
+    }
+
+    @Test
+    void findByStatus_filtersAcrossContracts() {
+        InterbankOtcNegotiation a = savedNegotiation("n-a");
+        InterbankOtcNegotiation b = savedNegotiation("n-b");
+        InterbankOtcNegotiation c = savedNegotiation("n-c");
+
+        contractRepository.save(buildContract(a, InterbankOtcContractStatus.ACTIVE));
+        contractRepository.save(buildContract(b, InterbankOtcContractStatus.EXERCISED));
+        contractRepository.save(buildContract(c, InterbankOtcContractStatus.EXPIRED));
+
+        assertThat(contractRepository.findByStatus(InterbankOtcContractStatus.ACTIVE)).hasSize(1);
+        assertThat(contractRepository.findByStatus(InterbankOtcContractStatus.EXERCISED)).hasSize(1);
+        assertThat(contractRepository.findByStatus(InterbankOtcContractStatus.EXPIRED)).hasSize(1);
+        assertThat(contractRepository.findByStatus(InterbankOtcContractStatus.CANCELLED)).isEmpty();
+    }
+
+    @Test
+    void multipleContractsPerNegotiationAreReturned() {
+        InterbankOtcNegotiation nego = savedNegotiation("n-multi");
+        contractRepository.save(buildContract(nego, InterbankOtcContractStatus.ACTIVE));
+        contractRepository.save(buildContract(nego, InterbankOtcContractStatus.EXPIRED));
+
+        assertThat(contractRepository.findByNegotiation_Id(nego.getId())).hasSize(2);
+    }
+}

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/interbank/repository/InterbankOtcNegotiationRepositoryIT.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/interbank/repository/InterbankOtcNegotiationRepositoryIT.java
@@ -1,0 +1,91 @@
+package rs.raf.banka2_bek.interbank.repository;
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import rs.raf.banka2_bek.interbank.model.InterbankOtcNegotiation;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class InterbankOtcNegotiationRepositoryIT {
+
+    @Autowired
+    private InterbankOtcNegotiationRepository repository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private InterbankOtcNegotiation buildSample(String routingNumber, String opaqueId) {
+        return InterbankOtcNegotiation.builder()
+                .negotiationRoutingNumber(routingNumber)
+                .negotiationOpaqueId(opaqueId)
+                .stockTicker("AAPL")
+                .settlementInstant(Instant.parse("2025-04-05T12:00:00Z"))
+                .pricePerUnitAmount(new BigDecimal("200.0000"))
+                .pricePerUnitCurrency("USD")
+                .premiumAmount(new BigDecimal("700.0000"))
+                .premiumCurrency("USD")
+                .amount(50)
+                .buyerRoutingNumber("111")
+                .buyerOpaqueId("b1")
+                .sellerRoutingNumber(routingNumber)
+                .sellerOpaqueId("s1")
+                .lastModifiedByRoutingNumber("111")
+                .lastModifiedByOpaqueId("b1")
+                .ongoing(true)
+                .updatedAt(Instant.parse("2025-04-01T10:00:00Z"))
+                .build();
+    }
+
+    @Test
+    void saveAndFindByForeignId() {
+        InterbankOtcNegotiation saved = repository.save(buildSample("222", "neg-opaque-1"));
+        assertThat(saved.getId()).isNotNull();
+
+        Optional<InterbankOtcNegotiation> found =
+                repository.findByNegotiationRoutingNumberAndNegotiationOpaqueId("222", "neg-opaque-1");
+        assertThat(found).isPresent();
+        assertThat(found.get().getAmount()).isEqualTo(50);
+        assertThat(found.get().isOngoing()).isTrue();
+    }
+
+    @Test
+    void findByForeignId_notFound_returnsEmpty() {
+        repository.save(buildSample("222", "neg-opaque-1"));
+
+        Optional<InterbankOtcNegotiation> found =
+                repository.findByNegotiationRoutingNumberAndNegotiationOpaqueId("999", "missing");
+        assertThat(found).isEmpty();
+    }
+
+    @Test
+    void uniqueConstraintOnForeignIdRejectsDuplicate() {
+        repository.saveAndFlush(buildSample("222", "dup-1"));
+
+        assertThatThrownBy(() -> {
+            repository.saveAndFlush(buildSample("222", "dup-1"));
+            entityManager.flush();
+        }).isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void differentForeignIdsCoexist() {
+        repository.saveAndFlush(buildSample("222", "n-a"));
+        repository.saveAndFlush(buildSample("222", "n-b"));
+        repository.saveAndFlush(buildSample("333", "n-a"));
+
+        assertThat(repository.findAll()).hasSize(3);
+    }
+}

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/investmentfund/service/InvestmentFundServiceTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/investmentfund/service/InvestmentFundServiceTest.java
@@ -1,0 +1,281 @@
+package rs.raf.banka2_bek.investmentfund.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.util.ReflectionTestUtils;
+import rs.raf.banka2_bek.auth.model.User;
+import rs.raf.banka2_bek.auth.service.EmployeeUserDetails;
+import rs.raf.banka2_bek.client.model.Client;
+import rs.raf.banka2_bek.client.repository.ClientRepository;
+import rs.raf.banka2_bek.employee.model.Employee;
+import rs.raf.banka2_bek.investmentfund.dto.ClientFundPositionDto;
+import rs.raf.banka2_bek.investmentfund.model.ClientFundPosition;
+import rs.raf.banka2_bek.investmentfund.model.InvestmentFund;
+import rs.raf.banka2_bek.investmentfund.repository.ClientFundPositionRepository;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class InvestmentFundServiceTest {
+
+    private static final String BANK_CLIENT_EMAIL = "banka2.entity@banka2.rs";
+
+    @Mock
+    private ClientFundPositionRepository clientFundPositionRepository;
+
+    @Mock
+    private ClientRepository clientRepository;
+
+    @InjectMocks
+    private InvestmentFundService investmentFundService;
+
+    @BeforeEach
+    void injectBankEmail() {
+        ReflectionTestUtils.setField(investmentFundService, "bankOwnerClientEmail", BANK_CLIENT_EMAIL);
+    }
+
+    private static ClientFundPosition position(long posId, Client client, long fundId, String fundName, String amount) {
+        return position(posId, client, fundId, fundName, amount, defaultManager());
+    }
+
+    private static ClientFundPosition position(long posId, Client client, long fundId, String fundName,
+                                               String amount, Employee manager) {
+        InvestmentFund fund = mock(InvestmentFund.class);
+        when(fund.getId()).thenReturn(fundId);
+        when(fund.getName()).thenReturn(fundName);
+        when(fund.getManager()).thenReturn(manager);
+        return ClientFundPosition.builder()
+                .id(posId)
+                .client(client)
+                .fund(fund)
+                .totalInvestedAmount(new BigDecimal(amount))
+                .build();
+    }
+
+    private static Employee defaultManager() {
+        return Employee.builder()
+                .id(1L)
+                .firstName("Nikola")
+                .lastName("Milenković")
+                .build();
+    }
+
+    private static Authentication authForUser(User user) {
+        return new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
+    }
+
+    private static Authentication authForEmployee(EmployeeUserDetails employee) {
+        return new UsernamePasswordAuthenticationToken(employee, null, employee.getAuthorities());
+    }
+
+    // ── listMyPositions: klijent ─────────────────────────────────────────────
+
+    @Test
+    void listMyPositions_mapsRowsForClientUser() {
+        User user = new User();
+        user.setEmail("stefan.jovanovic@gmail.com");
+        user.setRole("CLIENT");
+
+        Client client = mock(Client.class);
+        when(client.getId()).thenReturn(1L);
+
+        ClientFundPosition pos = position(99L, client, 10L, "Alpha Seed Fund", "10000.0000");
+
+        when(clientRepository.findByEmail("stefan.jovanovic@gmail.com")).thenReturn(Optional.of(client));
+        when(clientFundPositionRepository.findByClient_Id(1L)).thenReturn(List.of(pos));
+
+        List<ClientFundPositionDto> result = investmentFundService.listMyPositions(authForUser(user));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).fundName()).isEqualTo("Alpha Seed Fund");
+        assertThat(result.get(0).clientId()).isEqualTo(1L);
+        assertThat(result.get(0).totalInvestedAmountRsd()).isEqualByComparingTo("10000.0000");
+        assertThat(result.get(0).managerName()).isEqualTo("Nikola");
+        assertThat(result.get(0).managerLastname()).isEqualTo("Milenković");
+    }
+
+    @Test
+    void listMyPositions_managerWithNullNames_returnsNullManagerFields() {
+        User user = new User();
+        user.setEmail("client@gmail.com");
+        Client client = mock(Client.class);
+        when(client.getId()).thenReturn(5L);
+
+        Employee managerWithNoName = Employee.builder().id(2L).build();
+        ClientFundPosition pos = position(1L, client, 10L, "Fund X", "100.0000", managerWithNoName);
+
+        when(clientRepository.findByEmail("client@gmail.com")).thenReturn(Optional.of(client));
+        when(clientFundPositionRepository.findByClient_Id(5L)).thenReturn(List.of(pos));
+
+        List<ClientFundPositionDto> result = investmentFundService.listMyPositions(authForUser(user));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).managerName()).isNull();
+        assertThat(result.get(0).managerLastname()).isNull();
+    }
+
+    @Test
+    void listMyPositions_nullManager_returnsNullManagerFields() {
+        User user = new User();
+        user.setEmail("client2@gmail.com");
+        Client client = mock(Client.class);
+        when(client.getId()).thenReturn(6L);
+
+        ClientFundPosition pos = position(1L, client, 11L, "Fund Y", "200.0000", null);
+
+        when(clientRepository.findByEmail("client2@gmail.com")).thenReturn(Optional.of(client));
+        when(clientFundPositionRepository.findByClient_Id(6L)).thenReturn(List.of(pos));
+
+        List<ClientFundPositionDto> result = investmentFundService.listMyPositions(authForUser(user));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).managerName()).isNull();
+        assertThat(result.get(0).managerLastname()).isNull();
+    }
+
+    @Test
+    void listMyPositions_clientUserMissingInClientsTable_returnsEmpty() {
+        User user = new User();
+        user.setEmail("ghost@nowhere.rs");
+        user.setRole("CLIENT");
+
+        when(clientRepository.findByEmail("ghost@nowhere.rs")).thenReturn(Optional.empty());
+
+        assertThat(investmentFundService.listMyPositions(authForUser(user))).isEmpty();
+        verify(clientFundPositionRepository, never()).findByClient_Id(org.mockito.ArgumentMatchers.anyLong());
+    }
+
+    @Test
+    void listMyPositions_clientWithNoPositions_returnsEmpty() {
+        User user = new User();
+        user.setEmail("empty@gmail.com");
+        user.setRole("CLIENT");
+
+        Client client = mock(Client.class);
+        when(client.getId()).thenReturn(7L);
+
+        when(clientRepository.findByEmail("empty@gmail.com")).thenReturn(Optional.of(client));
+        when(clientFundPositionRepository.findByClient_Id(7L)).thenReturn(List.of());
+
+        assertThat(investmentFundService.listMyPositions(authForUser(user))).isEmpty();
+    }
+
+    @Test
+    void listMyPositions_sortsResultsByFundNameAscending() {
+        User user = new User();
+        user.setEmail("sorter@gmail.com");
+        Client client = mock(Client.class);
+        when(client.getId()).thenReturn(2L);
+
+        ClientFundPosition gamma = position(1L, client, 30L, "Gamma Fund", "300.0000");
+        ClientFundPosition alpha = position(2L, client, 10L, "Alpha Fund", "100.0000");
+        ClientFundPosition beta  = position(3L, client, 20L, "Beta Fund",  "200.0000");
+
+        when(clientRepository.findByEmail("sorter@gmail.com")).thenReturn(Optional.of(client));
+        when(clientFundPositionRepository.findByClient_Id(2L)).thenReturn(List.of(gamma, alpha, beta));
+
+        List<ClientFundPositionDto> result = investmentFundService.listMyPositions(authForUser(user));
+
+        assertThat(result).extracting(ClientFundPositionDto::fundName)
+                .containsExactly("Alpha Fund", "Beta Fund", "Gamma Fund");
+    }
+
+    // ── listMyPositions: supervizor (Napomena 2 — vidi bankine pozicije) ─────
+
+    @Test
+    void listMyPositions_supervisorReturnsBankPositions() {
+        Employee employee = Employee.builder()
+                .id(99L)
+                .firstName("Nikola")
+                .lastName("Milenković")
+                .email("nikola.milenkovic@banka.rs")
+                .username("nikola.milenkovic")
+                .build();
+        EmployeeUserDetails employeeUserDetails = new EmployeeUserDetails(employee);
+
+        Client bankClient = mock(Client.class);
+        when(bankClient.getId()).thenReturn(42L);
+        ClientFundPosition pos = position(1L, bankClient, 10L, "Alpha Seed Fund", "2500000.0000");
+
+        when(clientRepository.findByEmail(BANK_CLIENT_EMAIL)).thenReturn(Optional.of(bankClient));
+        when(clientFundPositionRepository.findByClient_Id(42L)).thenReturn(List.of(pos));
+
+        List<ClientFundPositionDto> result = investmentFundService.listMyPositions(authForEmployee(employeeUserDetails));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).clientId()).isEqualTo(42L);
+        verify(clientRepository, never()).findByEmail("nikola.milenkovic@banka.rs");
+    }
+
+    // ── listMyPositions: ivični slučajevi za auth ────────────────────────────
+
+    @Test
+    void listMyPositions_nullAuthentication_returnsEmpty() {
+        assertThat(investmentFundService.listMyPositions(null)).isEmpty();
+    }
+
+    @Test
+    void listMyPositions_nullPrincipal_returnsEmpty() {
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                null, null, List.of(new SimpleGrantedAuthority("ROLE_ANONYMOUS")));
+        assertThat(investmentFundService.listMyPositions(auth)).isEmpty();
+    }
+
+    @Test
+    void listMyPositions_unknownPrincipalType_returnsEmpty() {
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                "anonymous-string", null, List.of(new SimpleGrantedAuthority("ROLE_ANONYMOUS")));
+        assertThat(investmentFundService.listMyPositions(auth)).isEmpty();
+    }
+
+    // ── listBankPositions ────────────────────────────────────────────────────
+
+    @Test
+    void listBankPositions_resolvesBankClient() {
+        Client bankClient = mock(Client.class);
+        when(bankClient.getId()).thenReturn(42L);
+        ClientFundPosition pos = position(1L, bankClient, 10L, "Alpha Seed Fund", "2500000.0000");
+
+        when(clientRepository.findByEmail(BANK_CLIENT_EMAIL)).thenReturn(Optional.of(bankClient));
+        when(clientFundPositionRepository.findByClient_Id(42L)).thenReturn(List.of(pos));
+
+        List<ClientFundPositionDto> result = investmentFundService.listBankPositions();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).clientId()).isEqualTo(42L);
+        assertThat(result.get(0).fundName()).isEqualTo("Alpha Seed Fund");
+        assertThat(result.get(0).managerName()).isEqualTo("Nikola");
+        assertThat(result.get(0).managerLastname()).isEqualTo("Milenković");
+    }
+
+    @Test
+    void listBankPositions_bankClientMissing_returnsEmpty() {
+        when(clientRepository.findByEmail(BANK_CLIENT_EMAIL)).thenReturn(Optional.empty());
+
+        assertThat(investmentFundService.listBankPositions()).isEmpty();
+        verify(clientFundPositionRepository, never()).findByClient_Id(org.mockito.ArgumentMatchers.anyLong());
+    }
+
+    @Test
+    void listBankPositions_blankConfiguredEmail_returnsEmpty() {
+        ReflectionTestUtils.setField(investmentFundService, "bankOwnerClientEmail", "   ");
+
+        assertThat(investmentFundService.listBankPositions()).isEmpty();
+        verify(clientRepository, never()).findByEmail(org.mockito.ArgumentMatchers.anyString());
+    }
+}

--- a/banka2_bek/src/test/resources/application-test.properties
+++ b/banka2_bek/src/test/resources/application-test.properties
@@ -18,5 +18,9 @@ notification.password-reset-page-path=/reset-password
 notification.activation-page-path=/activate-account
 
 bank.registration-number=22200022
+# Email klijenta-vlasnika banke (po Napomenama 1 i 2 — moze biti sama banka kao
+# pravno lice ili druga osoba/firma vlasnik). Mora se poklapati sa email-om
+# koji seed.sql ubacuje u clients tabelu.
+bank.owner-client-email=banka2.entity@banka2.rs
 exchange.api.key=test
 exchange.api.url=http://localhost

--- a/seed.sql
+++ b/seed.sql
@@ -694,3 +694,85 @@ WHERE u.email = 'milica.nikolic@gmail.com' AND l.ticker = 'AMZN'
 AND NOT EXISTS (
     SELECT 1 FROM portfolios p WHERE p.user_id = u.id AND p.listing_id = l.id
 );
+
+
+-- ============================================================
+-- T12 — Vlasnik banke kao clients red + investicioni fond + pozicije
+-- ============================================================
+-- KONTEKST (Celina 4, Napomene 1 i 2):
+--   „Banka kao entitet ima vlasnika (klijenta), pa se bankine investicije vode
+--    pod tim klijentom. Klijent (u ClientFundPosition) je klijent koji je
+--    vlasnik banke.“
+--
+-- Po zadatku T12, vlasnika banke modelujemo kao Client sa imenom „Banka 2 d.o.o.“
+-- — to znaci da je u ovom seed-u sama banka (kao pravno lice) ujedno i klijent
+-- vlasnik. Drugim recima: klijent koji predstavlja vlasnika banke MOZE biti
+-- (i ovde JESTE) sama banka. Alternativa bi bila zaseban Client za fizickog
+-- osnivaca/drugu firmu — model isto podrzava (samo postavi drugi email u
+-- bank.owner-client-email i ubaci odgovarajuci clients red).
+--
+-- Na taj clients red pokazuje InvestmentFund.owner_client_id i pod njim se
+-- belezi svaka bankina pozicija u ClientFundPosition.
+--
+-- Razlika u odnosu na racune banke (zasto dva razlicita reda):
+--   * vlasnik fonda kao investicija   -> Client „Banka 2 d.o.o.“ (banka2.entity@banka2.rs)
+--   * vlasnik racuna fonda i ostalih
+--     bankinih racuna                 -> Company „Banka 2025 Tim 2“ (id=3)
+-- Ovo je NAMERNO razdvojeno jer Account.isOwnerValid() zahteva client XOR company,
+-- a svi bankini racuni vec koriste firmu kao vlasnika. Iako konceptualno oba reda
+-- predstavljaju „banku kao entitet“, zbog te ogranicenja u modelu (account mora
+-- imati ili klijenta ili firmu, ne oboje) tehnicki su to dva zasebna reda.
+-- Ne menjati bez koordinacije sa T7/T8 jer oni invest/withdraw rade preko `accounts`.
+
+INSERT INTO clients (first_name, last_name, date_of_birth, gender, email, phone, address,
+                     password, salt_password, active, created_at)
+SELECT 'Banka 2', 'd.o.o.', NULL, 'OTHER', 'banka2.entity@banka2.rs', '+381 11 000 0000', 'Beograd',
+       '$2b$10$FUjcSzK7CZKeX53YVU4JjeOIXLt5axbipO85OlQqw5Dopg47zfgRG',
+       'c2VlZF9iYW5rX2VudF9f', 1, NOW()
+FROM DUAL
+WHERE NOT EXISTS (SELECT 1 FROM clients c WHERE c.email = 'banka2.entity@banka2.rs');
+
+-- Račun fonda Alpha Seed — vlasnik je `companies` red banke (kao i ostali bankini računi).
+INSERT INTO accounts (account_number, account_type, account_subtype, currency_id,
+                      client_id, company_id, employee_id,
+                      balance, available_balance,
+                      daily_limit, monthly_limit,
+                      daily_spending, monthly_spending,
+                      maintenance_fee, expiration_date, status, name, created_at)
+SELECT '222000199999999901', 'BUSINESS', 'STANDARD', 8, NULL, 3, 1,
+       1000000.0000, 1000000.0000,
+       999999999.0000, 999999999.0000,
+       0.0000, 0.0000, 0.0000, '2050-01-01', 'ACTIVE', 'Alpha Seed — račun fonda', NOW()
+FROM DUAL
+WHERE NOT EXISTS (SELECT 1 FROM accounts a WHERE a.account_number = '222000199999999901');
+
+INSERT INTO investment_funds (name, description, minimum_contribution, manager_id, fund_account_id, owner_client_id, created_at, active)
+SELECT
+  'Alpha Seed Fund',
+  'Integracioni seed fond (T12)',
+  1000.0000,
+  1,
+  (SELECT id FROM accounts WHERE account_number = '222000199999999901' LIMIT 1),
+  (SELECT id FROM clients WHERE email = 'banka2.entity@banka2.rs' LIMIT 1),
+  NOW(),
+  1
+FROM DUAL
+WHERE NOT EXISTS (SELECT 1 FROM investment_funds f WHERE f.name = 'Alpha Seed Fund');
+
+INSERT INTO client_fund_positions (client_id, fund_id, total_invested_amount)
+SELECT c.id, f.id, 2500000.0000
+FROM clients c
+CROSS JOIN investment_funds f
+WHERE c.email = 'banka2.entity@banka2.rs' AND f.name = 'Alpha Seed Fund'
+AND NOT EXISTS (
+  SELECT 1 FROM client_fund_positions p WHERE p.client_id = c.id AND p.fund_id = f.id
+);
+
+INSERT INTO client_fund_positions (client_id, fund_id, total_invested_amount)
+SELECT c.id, f.id, 10000.0000
+FROM clients c
+CROSS JOIN investment_funds f
+WHERE c.email = 'stefan.jovanovic@gmail.com' AND f.name = 'Alpha Seed Fund'
+AND NOT EXISTS (
+  SELECT 1 FROM client_fund_positions p WHERE p.client_id = c.id AND p.fund_id = f.id
+);


### PR DESCRIPTION
## T12 — Inter-bank OTC entiteti + Banka kao klijent fonda + listMy/BankPositions

Closes #61 

### Šta je urađeno

**1) Novi inter-bank OTC entiteti (Protokol §2.3 + §3, Celina 5 (Nova))**

Postojeći intra-bank `otc/model/OtcOffer` i `OtcContract` čuvaju strane kao `Long` (ka lokalnim klijentima/zaposlenima) i nisu prikladni za inter-bank pregovore u kojima je druga strana opaque kompozitni `ForeignBankId{routingNumber, idString}`. Zato su uvedena **dva nova entiteta**:

- `interbank/model/InterbankOtcNegotiation.java`
  - kompozitni `foreignNegotiationRoutingNumber + foreignNegotiationIdString` (UNIQUE — brzi lookup po protokol-formi po §3.2/3.3/3.4)
  - `localPartyType` (BUYER/SELLER), `localPartyId/Role` — naša strana
  - `foreignPartyRoutingNumber + foreignPartyIdString` — strana strana (opaque, ne interpretiramo)
  - ticker, amount, pricePerUnit, premium, settlementDate (BigDecimal po §2.5)
  - `lastModifiedByRoutingNumber + idString` za pravilo turne (§3.3)
  - `ongoing` boolean (preslikava §3.4 OtcNegotiation shape) + status enum
- `interbank/model/InterbankOtcContract.java`
  - `sourceNegotiationId` (FK ka pregovoru)
  - lokalna strana + foreign strana, strikePrice, premium, settlementDate, status, exercisedAt
- Prateći enumi: `InterbankPartyType` (BUYER/SELLER), `InterbankOtcNegotiationStatus` (ACTIVE/ACCEPTED/DECLINED/CLOSED), `InterbankOtcContractStatus` (ACTIVE/EXERCISED/EXPIRED)

**2) Repozitorijumi**

- `InterbankOtcNegotiationRepository`:
  - `findByForeignNegotiationRoutingNumberAndForeignNegotiationIdString` — primarni lookup za PUT/GET/DELETE/accept handler-e (T2/T3)
  - `findByLocalPartyIdAndLocalPartyRoleAndStatus` — "Aktivne ponude" tab
  - `findByLocalPartyTypeAndStatus` — supervisor view
  - `sumActiveAmountForSellerAndTicker` — kvota check za §3.2 inbound (sa COALESCE 0 da nikad ne vraća null)
- `InterbankOtcContractRepository`:
  - `findBySourceNegotiationId` — 1:1 mapiranje pregovor→ugovor
  - `findByLocalPartyIdAndLocalPartyRole`, `findByLocalPartyTypeAndStatus`
  - `findByStatusAndSettlementDateBefore` — auto-expiry helper za scheduler (§2.7.2 "if not used, resources shall be un-reserved")

**3) seed.sql — Banka kao klijent (Celina 4 (Nova) §4406-4435 Napomena 1+2)**

Idempotentni seed (sve preko `WHERE NOT EXISTS`):
- novi klijent `Banka 2 d.o.o.` (email `banka2.doo@banka.rs`)
- 2 sample fonda (`Banka 2 Stable Income`, `Banka 2 Tech Growth`) sa `owner_client_id` → bank client
- backfill `UPDATE investment_funds SET owner_client_id = ... WHERE owner_client_id IS NULL` — bezbedan i za fondove koje T7 kreira preko `createFund` API-ja
- 2 sample `client_fund_positions` sa `userRole='CLIENT'` i `userId = bank client_id` da Profit Banke "Pozicije u fondovima" tab odmah ima nešto da prikaže

**4) `InvestmentFundService` — `listMyPositions` + `listBankPositions`**

- `listMyPositions(Long userId, String userRole)`:
  - vraća pozicije ulogovanog korisnika sa popunjenim `fundName`-om (batch-load fondova → bez N+1)
  - defensive null/blank check vraća prazan list
  - izvedena polja (`currentValue`, `percentOfFund`, `profit`) ostaju `null` — biće dopunjena kad T7+T10 završe `FundValueCalculator`
- `listBankPositions()`:
  - resolvuje banka client_id po email-u iz `bank.owner-client-email` propertyja → reuse `listMyPositions(bankClientId, "CLIENT")`
  - **graceful fallback**: ako banka klijent nije seed-ovan, vraća prazan list + warn log umesto 500-ke (Profit Banke FE renderuje "Banka nema pozicije" placeholder)
  - email-based lookup umesto fixed ID-ja jer je `clients.id` AUTO_INCREMENT — ne možemo ga forsirati u seedu bez konflikta
- `application.properties`: dodat `bank.owner-client-email=banka2.doo@banka.rs`

### Definicija Gotovog

- [x] Hibernate kreira nove tabele (`interbank_otc_negotiations`, `interbank_otc_contracts`) — verifikovano kroz `@SpringBootTest` koji pokreće `ddl-auto=create` na H2
- [x] Seed prošao u Docker rebuild-u, `Banka 2 d.o.o.` postoji u `clients` tabeli — INSERT je idempotentan
- [x] Profit Banke "Pozicije u fondovima" tab počinje da prikazuje prave podatke (ne prazan list) — `ProfitBankController.fundPositions()` poziva `listBankPositions()` koji sad vraća stvarne entitete
- [x] Unit testovi za repos

### Testovi

| Test                                          | Tests | Status |
|-----------------------------------------------|-------|--------|
| `InterbankOtcNegotiationRepositoryTest`       | 6     | PASS   |
| `InterbankOtcContractRepositoryTest`          | 5     | PASS   |
| `InvestmentFundServicePositionsTest`          | 7     | PASS   |
| **Full suite** (regression check)             | 2262  | PASS (0 failures, 0 errors) |

### Koordinacija

- **T2 (OTC outbound)** i **T3 (OTC inbound)** mogu odmah da koriste `InterbankOtcNegotiationRepository` i `InterbankOtcContractRepository` za persist. TODO blok iznad `OtcNegotiationService` već referencira ova polja.
- **T7 (createFund)** — `seed.sql` UPDATE statement je idempotentan; ako T7 doda svoje fondove preko API-ja, oni će automatski dobiti `owner_client_id` banke (osim ako T7 eksplicitno postavi drugi vlasnik).
- **T8 (FE)** — može odmah da konzumira `GET /funds/my-positions` i `GET /profit-bank/fund-positions`.
- **T10 (FundValueCalculator)** — kad bude gotov, dopuniti `InvestmentFundService.toClientFundPositionDto` da popuni `currentValue/percentOfFund/profit` umesto `null`.

### Napomene

- Inter-bank entiteti su **odvojeni sloj** od intra-bank `otc/model/*` (namene su različite, mešanje bi pokvarilo postojeći flow). Niko ne dira intra-bank kod.
- `InterbankOtcNegotiation.ongoing` je redundantan sa `status = ACTIVE`, ali se čuva kao odvojena kolona da odgovor `GET /negotiations/{rn}/{id}` može direktno da preslika protokolni `OtcNegotiation` shape (§3.4) bez enum mapiranja.

### Test plan

- [x] `mvn compile` čisto
- [x] `mvn test` — 2262/2262 PASS
- [ ] Docker rebuild + manual probe: `GET /profit-bank/fund-positions` vraća 2 reda (Stable Income + Tech Growth)
- [ ] Docker rebuild + manual probe: `GET /funds/my-positions` kao Stefan vraća prazan list (Stefan nema pozicija u seedu — proveriti negativan slučaj)