### PR TITLE
[T12] Inter-bank OTC entiteti + ownerClientId seed + listMyPositions/listBankPositions - Celina 4 + 5 #61

### DIFF
--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/model/InterbankOtcContract.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/model/InterbankOtcContract.java
@@ -1,0 +1,128 @@
+package rs.raf.banka2_bek.interbank.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * T12 — Inter-bank OTC opcioni ugovor (sklopljen kroz pregovor izmedju
+ * razlicitih banaka).
+ *
+ * Spec referenca:
+ *  - Protokol §2.7.2 Options (lifecycle, settlementDate, exec, expiry)
+ *  - Protokol §3.6 Accepting an offer (kako se ugovor formira)
+ *  - Protokol §3.6.1 Forming option contracts (mapiranje OtcOffer -> OptionDescription)
+ *  - Celina 4 (Nova) — Sklopljeni ugovori
+ *  - Celina 5 (Nova) — OTC Trgovina, Postignut dogovor
+ *
+ * Ugovor se kreira kada druga strana posalje GET /negotiations/{rn}/{id}/accept
+ * (§3.6). Pri kreiranju:
+ *   - kupac placa premium prodavcu (§3.6 4 postinga)
+ *   - prodavac rezervise hartije (§2.7.2)
+ *   - sourceNegotiation se prebacuje u status ACCEPTED i ongoing=false
+ *
+ * `negotiationId` u protokolnom OptionDescription (§2.7.2) je
+ * `ForeignBankId{ourRoutingNumber, sourceNegotiation.foreignNegotiationIdString}`
+ * — ID je generisan kod prodavceve banke, sto cini option pseudo-account
+ * dostupan samo prodavcu koji ce kasnije izvrsiti SAGA prenos vlasnistva.
+ *
+ * Ugovor je u ACTIVE statusu dok kupac ne iskoristi opciju (EXERCISED) ili
+ * dok ne istekne settlementDate (EXPIRED). Po §2.7.2: "if that option was
+ * not used, the resources stuck in an option shall be un-reserved" —
+ * scheduler proverava `settlementDate < today AND status == ACTIVE` i
+ * oslobadja rezervaciju (T9-style hook).
+ */
+@Entity
+@Table(name = "interbank_otc_contracts", indexes = {
+        @Index(name = "idx_ibotc_ctr_source_neg", columnList = "source_negotiation_id"),
+        @Index(name = "idx_ibotc_ctr_status_settle", columnList = "status, settlement_date"),
+        @Index(name = "idx_ibotc_ctr_local_party", columnList = "local_party_id, local_party_role")
+})
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class InterbankOtcContract {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * FK ka InterbankOtcNegotiation koji je doveo do ovog ugovora. Cuvan
+     * kao Long (ne @ManyToOne) — relacija je 1:1 i bez kaskadnog brisanja
+     * (audit trace cak i ako se pregovor obrise).
+     */
+    @Column(name = "source_negotiation_id", nullable = false)
+    private Long sourceNegotiationId;
+
+    // ─── Lokalna strana (kao u InterbankOtcNegotiation) ───────────────────
+    /** Da li smo MI kupac (BUYER) ili prodavac (SELLER) u ovom ugovoru. */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "local_party_type", nullable = false, length = 16)
+    private InterbankPartyType localPartyType;
+
+    /** Lokalni id korisnika (clients.id ili employees.id). */
+    @Column(name = "local_party_id", nullable = false)
+    private Long localPartyId;
+
+    /** Lokalna rola: "CLIENT" ili "EMPLOYEE". */
+    @Column(name = "local_party_role", nullable = false, length = 16)
+    private String localPartyRole;
+
+    // ─── Strana strana (kompozitni ForeignBankId po §2.3) ─────────────────
+    /** Routing number banke u kojoj je foreign strana. */
+    @Column(name = "foreign_party_routing_number", nullable = false)
+    private Integer foreignPartyRoutingNumber;
+
+    /** Opaque id string foreign strane (max 64 bajta po §2.3). */
+    @Column(name = "foreign_party_id_string", nullable = false, length = 64)
+    private String foreignPartyIdString;
+
+    // ─── Predmet ugovora (kopirano iz pregovora pri prihvatanju, §3.6.1) ──
+    /** Ticker hartije (po §2.7.3 jedinstveno; svi imaju isti data source). */
+    @Column(nullable = false, length = 16)
+    private String ticker;
+
+    /** Broj akcija (integer > 0 po protokolu §2.7.2). */
+    @Column(nullable = false, precision = 19, scale = 4)
+    private BigDecimal quantity;
+
+    /** Strike price = pricePerUnit iz pregovora (§3.6.1). */
+    @Column(name = "strike_price", nullable = false, precision = 19, scale = 4)
+    private BigDecimal strikePrice;
+
+    @Column(name = "strike_currency", nullable = false, length = 3)
+    private String strikeCurrency;
+
+    /** Premija placena prodavcu pri prihvatanju (§3.6 4 postinga). */
+    @Column(nullable = false, precision = 19, scale = 4)
+    private BigDecimal premium;
+
+    @Column(name = "premium_currency", nullable = false, length = 3)
+    private String premiumCurrency;
+
+    @Column(name = "settlement_date", nullable = false)
+    private LocalDate settlementDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    private InterbankOtcContractStatus status;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    /** Postavlja se kad kupac posalje exercise zahtev i SAGA potvrdi (§2.7.2). */
+    @Column(name = "exercised_at")
+    private LocalDateTime exercisedAt;
+
+    @PrePersist
+    void onCreate() {
+        if (createdAt == null) createdAt = LocalDateTime.now();
+        if (status == null) status = InterbankOtcContractStatus.ACTIVE;
+    }
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/model/InterbankOtcContractStatus.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/model/InterbankOtcContractStatus.java
@@ -1,0 +1,21 @@
+package rs.raf.banka2_bek.interbank.model;
+
+/**
+ * T12 — Stanje inter-bank OTC opcionog ugovora.
+ *
+ * Spec ref: Protokol §2.7.2 Options; Celina 5 (Nova) — Izvrsavanje kupoprodaje
+ * (SAGA pattern).
+ *
+ * Ugovor se kreira kada druga strana prihvati (§3.6) — premium se odmah
+ * placa kupcu->prodavcu, hartije se rezervisu kod prodavca. Ugovor je
+ * EXERCISED kad kupac iskoristi opciju pre `settlementDate`-a, EXPIRED
+ * inace (rezervacija hartija se vraca prodavcu).
+ */
+public enum InterbankOtcContractStatus {
+    /** Ugovor vazeci, kupac jos nije iskoristio opciju, settlementDate nije prosao. */
+    ACTIVE,
+    /** Kupac iskoristio opciju i transakcija je commitovana. Vidi protokol §2.7.2. */
+    EXERCISED,
+    /** Settlement datum prosao bez iskoriscenja — rezervacija se oslobadja. */
+    EXPIRED
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/model/InterbankOtcNegotiation.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/model/InterbankOtcNegotiation.java
@@ -1,0 +1,197 @@
+package rs.raf.banka2_bek.interbank.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * T12 — Inter-bank OTC pregovor (kupac i prodavac u razlicitim bankama).
+ *
+ * Spec referenca:
+ *  - Protokol §2.3 Foreign object identifiers (kompozitni ForeignBankId)
+ *  - Protokol §3 OTC negotiation protocol (§3.1–§3.7)
+ *  - Celina 5 (Nova) — OTC Trgovina (Pregovaranje, Postignut dogovor)
+ *  - Celina 4 (Nova) — Aktivne ponude (entitet polja)
+ *
+ * Razlika u odnosu na intra-bank `otc/model/OtcOffer`:
+ *   - Strana iz druge banke je kompozitni opaque ID (routingNumber + idString)
+ *     koji nas (po §2.3) NE smemo interpretirati. Zato cuvamo string id, ne
+ *     FK ka lokalnoj tabeli klijenata/zaposlenih.
+ *   - Pregovor ima eksplicitnu lokalnu/foreign stranu — `localPartyType`
+ *     odredjuje da li smo MI kupac (BUYER) ili prodavac (SELLER), i ko od
+ *     `localParty*` / `foreignParty*` polja je tudja banka.
+ *
+ * Autoritativna kopija pregovora je uvek kod prodavceve banke (§3.2). Ako
+ * smo mi prodavac (`localPartyType == SELLER`), `foreignNegotiationId`
+ * generisemo lokalno (UUID) i vracamo ga kupcu kao `ForeignBankId{
+ * ourRoutingNumber, generatedId}`. Ako smo kupac, `foreignNegotiationId`
+ * je sto nam je vratila partner banka iz POST /negotiations.
+ *
+ * Pravilo turne (§3.3):
+ *   - turn je buyer ako lastModifiedBy != buyerId
+ *   - turn je seller ako lastModifiedBy != sellerId
+ * Suprotna strana ne sme postavljati counter-offer dok je njen ne-red
+ * (handler odbija sa 409 Conflict).
+ *
+ * NE prosirivati intra-bank `otc/model/OtcOffer` — namene su razlicite i
+ * mesanje bi pokvarilo postojeci flow (Long vs ForeignBankId tipovi za
+ * strane, drugaciji status enum, drugaciji lifecycle).
+ *
+ * KORISNICI ENTITETA:
+ *   T2 (OTC outbound) — kreira/azurira pri slanju ka partner banci
+ *   T3 (OTC inbound)  — kreira/azurira pri primanju zahteva (POST/PUT/DELETE
+ *                       /accept handler-i)
+ *   listMyPositions / listBankPositions u InvestmentFundService NE
+ *                       interaguju sa ovim entitetom (T12 cuva i pozicije
+ *                       u fondu, ali pozicije nisu OTC pregovori).
+ */
+@Entity
+@Table(name = "interbank_otc_negotiations", indexes = {
+        @Index(
+                name = "idx_ibotc_neg_foreign_id",
+                columnList = "foreign_negotiation_routing_number, foreign_negotiation_id_string",
+                unique = true
+        ),
+        @Index(name = "idx_ibotc_neg_status_modified", columnList = "status, last_modified_at"),
+        @Index(name = "idx_ibotc_neg_local_party", columnList = "local_party_id, local_party_role")
+})
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class InterbankOtcNegotiation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // ─── Foreign negotiation ID (§2.3, §3.2) ──────────────────────────────
+    // Kompozitni ID koji se razmenjuje izmedju banaka. Po §3.2,
+    // prodavceva banka ga generise, a kupceva banka ga koristi za
+    // sve naredne PUT/GET/DELETE/accept zahteve.
+    /** Routing number banke koja je generisala ovaj negotiationId (uvek = prodavceva banka). */
+    @Column(name = "foreign_negotiation_routing_number", nullable = false)
+    private Integer foreignNegotiationRoutingNumber;
+
+    /** Opaque id string (max 64 bajta po §2.3). */
+    @Column(name = "foreign_negotiation_id_string", nullable = false, length = 64)
+    private String foreignNegotiationIdString;
+
+    // ─── Lokalna i strana strana ──────────────────────────────────────────
+    /** Da li smo MI kupac (BUYER) ili prodavac (SELLER) u ovom pregovoru. */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "local_party_type", nullable = false, length = 16)
+    private InterbankPartyType localPartyType;
+
+    /** Lokalni id korisnika (clients.id ili employees.id, zavisno od role). */
+    @Column(name = "local_party_id", nullable = false)
+    private Long localPartyId;
+
+    /**
+     * Lokalna rola: "CLIENT" ili "EMPLOYEE". Po Celini 5 (Nova) §840-848
+     * "Klijenti vide ponude Klijenata, Aktuari vide ponude Aktuara" — pravilo
+     * se proverava na FE ili u service sloju (T2/T3), ovde je informativno.
+     */
+    @Column(name = "local_party_role", nullable = false, length = 16)
+    private String localPartyRole;
+
+    /** Routing number banke u kojoj je foreign strana. */
+    @Column(name = "foreign_party_routing_number", nullable = false)
+    private Integer foreignPartyRoutingNumber;
+
+    /** Opaque id string foreign strane (max 64 bajta po §2.3, ne interpretiramo ga). */
+    @Column(name = "foreign_party_id_string", nullable = false, length = 64)
+    private String foreignPartyIdString;
+
+    // ─── Predmet pregovora ────────────────────────────────────────────────
+    /**
+     * Ticker hartije o kojoj se pregovara. Po protokolu §2.7.3, akcije se
+     * jedinstveno identifikuju ticker-om i sve banke moraju znati iste
+     * ticker-e (isti data source). Drzimo string, ne @ManyToOne ka Listing,
+     * jer u inter-bank kontekstu nismo garantovani da je listing prisutan
+     * kod nas (FE ce resolve-ovati ime preko stock servisa kad treba).
+     */
+    @Column(nullable = false, length = 16)
+    private String ticker;
+
+    /** Broj akcija u pregovoru (integer > 0 po protokolu §2.7.2). */
+    @Column(nullable = false, precision = 19, scale = 4)
+    private BigDecimal amount;
+
+    /**
+     * Cena po akciji u listing valuti (vidi `priceCurrency`). BigDecimal
+     * po protokolu §2.5 (NE float64).
+     */
+    @Column(name = "price_per_unit", nullable = false, precision = 19, scale = 4)
+    private BigDecimal pricePerUnit;
+
+    /** ISO4217 kod valute za pricePerUnit (npr. "USD", "EUR"). */
+    @Column(name = "price_currency", nullable = false, length = 3)
+    private String priceCurrency;
+
+    /** Premija za opcioni ugovor — placa je kupac prodavcu kad pregovor bude prihvacen (§3.6). */
+    @Column(nullable = false, precision = 19, scale = 4)
+    private BigDecimal premium;
+
+    /** Valuta premije (najcesce ista kao pricecurrency, ali protokol dozvoljava razliku). */
+    @Column(name = "premium_currency", nullable = false, length = 3)
+    private String premiumCurrency;
+
+    /** Datum dospeca opcije — posle ovoga ugovor istice ako nije iskoriscen (§2.7.2). */
+    @Column(name = "settlement_date", nullable = false)
+    private LocalDate settlementDate;
+
+    // ─── Pravilo turne (§3.3) ─────────────────────────────────────────────
+    /**
+     * ForeignBankId.routingNumber strane koja je poslednja izmenila pregovor.
+     * Koristi se za pravilo turne: turn je buyer ako lastModifiedBy != buyerId.
+     */
+    @Column(name = "last_modified_by_routing_number", nullable = false)
+    private Integer lastModifiedByRoutingNumber;
+
+    /** ForeignBankId.id strane koja je poslednja izmenila pregovor. */
+    @Column(name = "last_modified_by_id_string", nullable = false, length = 64)
+    private String lastModifiedByIdString;
+
+    // ─── Stanje ───────────────────────────────────────────────────────────
+    /**
+     * §3.4 OtcNegotiation polje — true dok je pregovor otvoren. Postaje
+     * false kad bilo koja strana posalje DELETE /negotiations (§3.5) ili
+     * kad se sklopi ugovor (§3.6).
+     *
+     * Nezavisno polje od `status`-a: redundantno za brze GET-ove ali tacno
+     * preslikava protokol shape (klijenti banke ce dobiti raw boolean iz
+     * GET /negotiations/{rn}/{id}).
+     */
+    @Column(name = "is_ongoing", nullable = false)
+    @ColumnDefault("1")
+    private boolean ongoing = true;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    private InterbankOtcNegotiationStatus status;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "last_modified_at", nullable = false)
+    private LocalDateTime lastModifiedAt;
+
+    @PrePersist
+    void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        if (createdAt == null) createdAt = now;
+        if (lastModifiedAt == null) lastModifiedAt = now;
+        if (status == null) status = InterbankOtcNegotiationStatus.ACTIVE;
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        lastModifiedAt = LocalDateTime.now();
+    }
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/model/InterbankOtcNegotiationStatus.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/model/InterbankOtcNegotiationStatus.java
@@ -1,0 +1,22 @@
+package rs.raf.banka2_bek.interbank.model;
+
+/**
+ * T12 — Stanje inter-bank OTC pregovora.
+ *
+ * Spec ref: Protokol §3 OTC negotiation; Celina 5 (Nova) — Pregovaranje.
+ *
+ * `isOngoing` polje na entitetu je derivat statusa: true iff status == ACTIVE.
+ * Drzimo ga kao odvojenu kolonu radi protokol §3.4 odgovora (`OtcNegotiation`
+ * tip nosi `isOngoing` boolean) i da se izbegnu enum-prefix mismatch-evi
+ * kad partner banka chita state preko GET /negotiations/{rn}/{id}.
+ */
+public enum InterbankOtcNegotiationStatus {
+    /** Pregovor u toku — jedna strana ceka odgovor druge. */
+    ACTIVE,
+    /** Druga strana je prihvatila — kreiran je InterbankOtcContract. */
+    ACCEPTED,
+    /** Strana koja nije bila na potezu odustala (DELETE /negotiations, §3.5). */
+    DECLINED,
+    /** Pregovor zatvoren bez sklapanja ugovora (npr. timeout, admin akcija). */
+    CLOSED
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/model/InterbankPartyType.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/model/InterbankPartyType.java
@@ -1,0 +1,20 @@
+package rs.raf.banka2_bek.interbank.model;
+
+/**
+ * T12 — Spec ref: Protokol §3 OTC negotiation, Celina 5 (Nova) "OTC Trgovina".
+ *
+ * U inter-bank OTC pregovoru, sa nase strane (lokalne banke) ucestvuje
+ * jedna od dve uloge: kupac ili prodavac. Druga strana je u partnerskoj
+ * banci i identifikuje se kompozitnim ForeignBankId-jem.
+ *
+ * Pravilo turne (§3.3):
+ *   - turn je buyer ako lastModifiedBy != buyerId
+ *   - turn je seller ako lastModifiedBy != sellerId
+ * Autoritativna kopija pregovora je uvek kod prodavceve banke (§3.2).
+ */
+public enum InterbankPartyType {
+    /** Mi smo kupac opcije; prodavac je u partnerskoj banci. */
+    BUYER,
+    /** Mi smo prodavac (autoritativni vlasnik pregovora); kupac je u partnerskoj banci. */
+    SELLER
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/repository/InterbankOtcContractRepository.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/repository/InterbankOtcContractRepository.java
@@ -1,0 +1,51 @@
+package rs.raf.banka2_bek.interbank.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import rs.raf.banka2_bek.interbank.model.InterbankOtcContract;
+import rs.raf.banka2_bek.interbank.model.InterbankOtcContractStatus;
+import rs.raf.banka2_bek.interbank.model.InterbankPartyType;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * T12 — Repository za inter-bank OTC opcione ugovore.
+ *
+ * Spec ref: Protokol §2.7.2 Options, §3.6 Accepting an offer; Celina 4
+ * (Nova) — Sklopljeni ugovori; Celina 5 (Nova) — Postignut dogovor.
+ *
+ * KORISNICI:
+ *   T2/T3        — kreira pri prihvatanju ponude (§3.6) i azurira pri exercise
+ *   FE           — `findByLocalParty...` za "Sklopljeni ugovori" tab
+ *   ExpiryScheduler (kasnije) — `findByStatusAndSettlementDateBefore` za auto-expire
+ */
+public interface InterbankOtcContractRepository extends JpaRepository<InterbankOtcContract, Long> {
+
+    /** 1:1 mapiranje pregovor -> ugovor. Vraca .empty() ako pregovor nije rezultovao ugovorom. */
+    Optional<InterbankOtcContract> findBySourceNegotiationId(Long sourceNegotiationId);
+
+    /**
+     * Sklopljeni ugovori za datog korisnika (BUYER ili SELLER), bilo kog
+     * statusa. Koristi se za "Sklopljeni ugovori" tab — FE filtrira po
+     * statusu (vazeci/istekli) na klijent strani.
+     */
+    List<InterbankOtcContract> findByLocalPartyIdAndLocalPartyRole(
+            Long localPartyId, String localPartyRole);
+
+    /**
+     * Aktivni ugovori za datu lokalnu stranu (BUYER ili SELLER) — koristi
+     * se npr. za reservaciju hartija prodavca (po §2.7.2 trebamo znati
+     * koje ugovore drzimo "live" da ne overcommit-ujemo).
+     */
+    List<InterbankOtcContract> findByLocalPartyTypeAndStatus(
+            InterbankPartyType localPartyType, InterbankOtcContractStatus status);
+
+    /**
+     * Auto-expiry helper: ugovori cija je settlementDate prosao a status je
+     * jos ACTIVE. Scheduler ce ih pokupiti i pozvati expire() (oslobadja
+     * rezervaciju hartija po §2.7.2).
+     */
+    List<InterbankOtcContract> findByStatusAndSettlementDateBefore(
+            InterbankOtcContractStatus status, LocalDate settlementDateBefore);
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/repository/InterbankOtcNegotiationRepository.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/repository/InterbankOtcNegotiationRepository.java
@@ -1,0 +1,72 @@
+package rs.raf.banka2_bek.interbank.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import rs.raf.banka2_bek.interbank.model.InterbankOtcNegotiation;
+import rs.raf.banka2_bek.interbank.model.InterbankOtcNegotiationStatus;
+import rs.raf.banka2_bek.interbank.model.InterbankPartyType;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * T12 — Repository za inter-bank OTC pregovore.
+ *
+ * Spec ref: Protokol §3 OTC negotiation; Celina 5 (Nova) OTC Trgovina.
+ *
+ * KORISNICI:
+ *   T2 outbound — `findByForeignNegotiationRoutingNumberAndForeignNegotiationIdString`
+ *                 za sync sa partner bankom (createNegotiation, postCounterOffer)
+ *   T3 inbound  — isto za POST/PUT/GET/DELETE/accept handler-e
+ *   FE          — `findByLocalParty...` za UI prikaz "Aktivne ponude" tab-a
+ */
+public interface InterbankOtcNegotiationRepository extends JpaRepository<InterbankOtcNegotiation, Long> {
+
+    /**
+     * Lookup po protokol-formi negotiation ID-ja (§2.3 ForeignBankId).
+     * Pre svake mutacije (PUT/DELETE/accept) handler mora prvo da resolvuje
+     * lokalni entitet preko ovog metoda.
+     *
+     * @return Optional.empty() ako pregovor sa tim ID-jem ne postoji.
+     */
+    Optional<InterbankOtcNegotiation> findByForeignNegotiationRoutingNumberAndForeignNegotiationIdString(
+            Integer foreignNegotiationRoutingNumber, String foreignNegotiationIdString);
+
+    /**
+     * Aktivne ponude po lokalnoj strani — koristi se za "Aktivne ponude" tab
+     * u OTC Ponude i Ugovori portalu (Celina 4 (Nova)).
+     *
+     * @param localPartyId   id korisnika (clients.id ili employees.id)
+     * @param localPartyRole "CLIENT" ili "EMPLOYEE"
+     */
+    List<InterbankOtcNegotiation> findByLocalPartyIdAndLocalPartyRoleAndStatus(
+            Long localPartyId, String localPartyRole, InterbankOtcNegotiationStatus status);
+
+    /**
+     * Sve aktivne pregovore u kojima smo BUYER ili SELLER, bez obzira na
+     * konkretnog korisnika — supervisor view.
+     */
+    List<InterbankOtcNegotiation> findByLocalPartyTypeAndStatus(
+            InterbankPartyType localPartyType, InterbankOtcNegotiationStatus status);
+
+    /**
+     * Provera kvota/ovecounting: pri prihvatanju nove ponude moramo
+     * proveriti da seller jos uvek ima dovoljno javnih akcija nakon
+     * uracunavanja svih ACTIVE pregovora i ACCEPTED ugovora (§3.2 inbound
+     * validacija u T3).
+     *
+     * Filter `localPartyType = SELLER` jer mi smo prodavac u tim
+     * pregovorima (autoritativna kopija je kod nas).
+     */
+    @Query("select coalesce(sum(n.amount), 0) from InterbankOtcNegotiation n " +
+            "where n.localPartyType = rs.raf.banka2_bek.interbank.model.InterbankPartyType.SELLER " +
+            "and n.localPartyId = :sellerId " +
+            "and n.localPartyRole = :sellerRole " +
+            "and n.ticker = :ticker " +
+            "and n.status = rs.raf.banka2_bek.interbank.model.InterbankOtcNegotiationStatus.ACTIVE")
+    java.math.BigDecimal sumActiveAmountForSellerAndTicker(
+            @Param("sellerId") Long sellerId,
+            @Param("sellerRole") String sellerRole,
+            @Param("ticker") String ticker);
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/investmentfund/service/InvestmentFundService.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/investmentfund/service/InvestmentFundService.java
@@ -2,13 +2,20 @@ package rs.raf.banka2_bek.investmentfund.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import rs.raf.banka2_bek.client.repository.ClientRepository;
 import rs.raf.banka2_bek.investmentfund.dto.InvestmentFundDtos.*;
+import rs.raf.banka2_bek.investmentfund.model.ClientFundPosition;
+import rs.raf.banka2_bek.investmentfund.model.InvestmentFund;
+import rs.raf.banka2_bek.investmentfund.repository.ClientFundPositionRepository;
 import rs.raf.banka2_bek.investmentfund.repository.InvestmentFundRepository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /*
 ================================================================================
@@ -75,10 +82,23 @@ import java.util.List;
 public class InvestmentFundService {
 
     private final InvestmentFundRepository investmentFundRepository;
-    // TODO: injectovati ostale potrebne repoze + FundValueCalculator + CurrencyConversionService:
-    //   ClientFundPositionRepository, ClientFundTransactionRepository, FundValueSnapshotRepository,
-    //   AccountRepository, PortfolioRepository, ListingRepository, FundValueCalculator,
-    //   CurrencyConversionService, FundLiquidationService
+    // T12 (P9 + listMyPositions): repoze za pozicije + lookup klijenta-vlasnika banke.
+    // Ostale zavisnosti (FundValueCalculator, CurrencyConversionService,
+    // ClientFundTransactionRepository, FundLiquidationService, ...) ce dodati T7-T9.
+    private final ClientFundPositionRepository clientFundPositionRepository;
+    private final ClientRepository clientRepository;
+
+    /**
+     * T12 — fallback strategija za "Banka kao klijent fonda" (Celina 4 (Nova) §4406-4435).
+     *
+     * Email pod kojim seed.sql kreira "Banka 2 d.o.o." klijenta. Po default-u
+     * "banka2.doo@banka.rs" (vidi application.properties + seed.sql).
+     * InvestmentFundService.listBankPositions koristi ga da resolvuje
+     * `clients.id` u runtime (jer client_id je auto-generisan i ne mozemo ga
+     * forsirati na konstantu).
+     */
+    @Value("${bank.owner-client-email:banka2.doo@banka.rs}")
+    private String bankOwnerClientEmail;
 
     @Transactional
     public InvestmentFundDetailDto createFund(CreateFundDto dto, Long supervisorId) {
@@ -163,28 +183,99 @@ public class InvestmentFundService {
                 + "tx ostaje PENDING dok FundLiquidationService ne proda hartije.");
     }
 
+    /**
+     * T12 — Spec Celina 4 (Nova) "Moj portfolio -> Moji fondovi page".
+     *
+     * Vraca sve pozicije (ClientFundPosition) za autentifikovanog korisnika.
+     * Pozicija se identifikuje (userId, userRole) parom — supervizor moze
+     * imati pozicije i kao CLIENT (privatne) i preko bankine `ownerClientId`
+     * (kroz listBankPositions, ne ovde).
+     *
+     * Izvedena polja (currentValue, percentOfFund, profit) ostaju null:
+     *  - zavise od FundValueCalculator-a koji T7+T10 jos pisu (FundValueSnapshot
+     *    + ListingRepository + CurrencyConversionService)
+     *  - kad budu dostupni, dopuni `toClientFundPositionDto` mapper
+     *    (umesto null, popuni iz cached snapshot-a ili racunaj live)
+     *
+     * Koristi se iz InvestmentFundController.GET /funds/my-positions.
+     */
     public List<ClientFundPositionDto> listMyPositions(Long userId, String userRole) {
-        throw new UnsupportedOperationException("TODO");
+        if (userId == null || userRole == null || userRole.isBlank()) {
+            return List.of();
+        }
+        List<ClientFundPosition> positions =
+                clientFundPositionRepository.findByUserIdAndUserRole(userId, userRole);
+        if (positions.isEmpty()) {
+            return List.of();
+        }
+        // Batch-load fondova da izbegnemo N+1 lookup za fundName u DTO-u.
+        List<Long> fundIds = positions.stream().map(ClientFundPosition::getFundId).distinct().toList();
+        Map<Long, String> fundIdToName = investmentFundRepository.findAllById(fundIds).stream()
+                .collect(Collectors.toMap(InvestmentFund::getId, InvestmentFund::getName));
+        return positions.stream()
+                .map(p -> toClientFundPositionDto(p, fundIdToName.get(p.getFundId())))
+                .toList();
     }
 
     /**
-     * P9 — Spec Celina 4 (Nova) §4222 Napomena 2: Banka kao klijent fonda.
-     * Ovo vraca sve ClientFundPosition entitete gde je userRole='CLIENT' i
-     * userId == InvestmentFund.ownerClientId banke.
+     * T12 — Spec Celina 4 (Nova) §4406-4435 (Napomena 1+2): Banka kao klijent fonda.
      *
-     * Implementacija (kad bude):
-     *  Long ownerClientId = bankProperties.getOwnerClientId();
-     *  return positionRepository
-     *      .findByUserIdAndUserRole(ownerClientId, "CLIENT")
-     *      .stream().map(this::toClientFundPositionDto).toList();
+     * Vraca sve pozicije gde je vlasnik klijent koji predstavlja banku
+     * (userRole='CLIENT', userId == bank.owner-client-id). Koristi se
+     * iz Profit Banke portala "Pozicije u fondovima" tab.
      *
-     * Trenutno baca UnsupportedOperationException; ProfitBankController
-     * lovi tu i vraca prazan list (graceful fallback) tako da FE moze
-     * renderovati "Banka nema pozicije" placeholder.
+     * Resolvovanje banka client_id-ja:
+     *  1) lookup u clients tabeli po email-u iz `bank.owner-client-email`
+     *     property-ja (default "banka2.doo@banka.rs")
+     *  2) ako klijent ne postoji — vrati prazan list (Profit Banke FE
+     *     renderuje "Banka nema pozicije" placeholder)
+     *
+     * Razlog za email-based resolvovanje umesto fixed ID-ja: clients.id
+     * je AUTO_INCREMENT pa ne mozemo seed-ovati eksplicitan ID bez
+     * konflikta. Email je jedinstven (uk_clients_email constraint) i
+     * stabilan kroz re-seed.
      */
     public List<ClientFundPositionDto> listBankPositions() {
-        throw new UnsupportedOperationException(
-                "TODO P9: implementirati listBankPositions — vidi javadoc iznad");
+        Long bankClientId = clientRepository.findByEmail(bankOwnerClientEmail)
+                .map(c -> c.getId())
+                .orElse(null);
+        if (bankClientId == null) {
+            // Banka klijent nije seed-ovan — graceful fallback (Profit Banke
+            // FE prikazuje "Banka nema pozicije" placeholder umesto greske).
+            log.warn("Bank owner client (email={}) not found — returning empty bank positions list. "
+                    + "Add seed entry or set bank.owner-client-email to a valid client.",
+                    bankOwnerClientEmail);
+            return List.of();
+        }
+        // userRole je uvek "CLIENT" za bankine pozicije (Napomena 2: "Klijent
+        // je klijent koji je vlasnik banke" — banka se ponasa kao obican CLIENT).
+        return listMyPositions(bankClientId, "CLIENT");
+    }
+
+    /**
+     * T12 — privatni mapper iz domena (ClientFundPosition) u FE DTO.
+     * Polja `currentValue`, `percentOfFund`, `profit` ostaju null jer
+     * zavise od FundValueCalculator-a koji T7+T10 jos pisu. Kad budu
+     * dostupni, prosiri ovde (npr. inject FundValueCalculator i racunaj
+     * iz live snapshot-a ili poslednjeg FundValueSnapshot reda).
+     */
+    private ClientFundPositionDto toClientFundPositionDto(ClientFundPosition position, String fundName) {
+        ClientFundPositionDto dto = new ClientFundPositionDto();
+        dto.setId(position.getId());
+        dto.setFundId(position.getFundId());
+        dto.setFundName(fundName);
+        dto.setUserId(position.getUserId());
+        dto.setUserRole(position.getUserRole());
+        // userName: T7+T8 ce dopuniti rezolvujuci po (userId, userRole) iz
+        // clients ili employees tabele. Trenutno ostaje null.
+        dto.setUserName(null);
+        dto.setTotalInvested(position.getTotalInvested());
+        // Izvedena polja — null dok FundValueCalculator (T7+T10) ne bude gotov.
+        dto.setCurrentValue(null);
+        dto.setPercentOfFund(null);
+        dto.setProfit(null);
+        dto.setLastModifiedAt(position.getLastModifiedAt());
+        return dto;
     }
 
     /**

--- a/banka2_bek/src/main/resources/application.properties
+++ b/banka2_bek/src/main/resources/application.properties
@@ -151,3 +151,19 @@ interbank.my-routing-number=222
 interbank.partners[0].routing-number=999
 interbank.partners[0].base-url=http://localhost:9999/
 interbank.partners[0].inbound-token=dev-placeholder
+
+# ============================================================================
+# BANK AS A CLIENT (T12 — Celina 4 (Nova) Napomena 1+2)
+# ============================================================================
+# Banka kao entitet investira u sopstvene fondove preko "vlasnik banke"
+# klijenta. ClientFundPosition koristi userRole='CLIENT' i userId =
+# bank.owner-client-id pri tracking-u banke kao investitora.
+#
+# Vrednost je client.id reda iz `clients` tabele koji predstavlja banku.
+# Seed.sql kreira klijenta sa email='banka2.doo@banka.rs'; kao fallback,
+# InvestmentFundService.listBankPositions koristi taj email lookup ako
+# property nije postavljen (omogucava da seed bira id, jer GENERATED).
+#
+# U produkciji moze se eksplicitno setovati pre boot-a:
+#   bank.owner-client-id=5
+bank.owner-client-email=banka2.doo@banka.rs

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/interbank/repository/InterbankOtcContractRepositoryTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/interbank/repository/InterbankOtcContractRepositoryTest.java
@@ -1,0 +1,177 @@
+package rs.raf.banka2_bek.interbank.repository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import rs.raf.banka2_bek.interbank.model.InterbankOtcContract;
+import rs.raf.banka2_bek.interbank.model.InterbankOtcContractStatus;
+import rs.raf.banka2_bek.interbank.model.InterbankPartyType;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * T12 — Integration test za InterbankOtcContractRepository.
+ *
+ * Pokriva: persist + lookup po sourceNegotiationId, pretrage po lokalnoj
+ * strani, auto-expiry helper findByStatusAndSettlementDateBefore.
+ *
+ * NAPOMENA: Spring Boot 4 je uklonio @DataJpaTest iz default test-autoconfigure
+ * modula — koristimo @SpringBootTest sa H2 (application-test.properties).
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class InterbankOtcContractRepositoryTest {
+
+    @Autowired
+    private InterbankOtcContractRepository repository;
+
+    private InterbankOtcContract buildBuyerSideContract(Long sourceNegId, String ticker,
+                                                        BigDecimal qty, LocalDate settlement,
+                                                        InterbankOtcContractStatus status) {
+        // Mi smo BUYER — kupili smo opciju od partner banke (111).
+        InterbankOtcContract c = new InterbankOtcContract();
+        c.setSourceNegotiationId(sourceNegId);
+        c.setLocalPartyType(InterbankPartyType.BUYER);
+        c.setLocalPartyId(7L);
+        c.setLocalPartyRole("CLIENT");
+        c.setForeignPartyRoutingNumber(111);
+        c.setForeignPartyIdString("partner-seller-77");
+        c.setTicker(ticker);
+        c.setQuantity(qty);
+        c.setStrikePrice(new BigDecimal("200.00"));
+        c.setStrikeCurrency("USD");
+        c.setPremium(new BigDecimal("1150.00"));
+        c.setPremiumCurrency("USD");
+        c.setSettlementDate(settlement);
+        c.setStatus(status);
+        return c;
+    }
+
+    @BeforeEach
+    void cleanUp() {
+        repository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("save + findBySourceNegotiationId — round-trip")
+    void persistAndLookupBySource() {
+        InterbankOtcContract toSave = buildBuyerSideContract(
+                42L, "AAPL", new BigDecimal("50"),
+                LocalDate.now().plusDays(30), InterbankOtcContractStatus.ACTIVE);
+
+        InterbankOtcContract saved = repository.save(toSave);
+
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getCreatedAt()).isNotNull();
+        // @PrePersist treba da postavi default ACTIVE.
+        assertThat(saved.getStatus()).isEqualTo(InterbankOtcContractStatus.ACTIVE);
+
+        Optional<InterbankOtcContract> found = repository.findBySourceNegotiationId(42L);
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getTicker()).isEqualTo("AAPL");
+        assertThat(found.get().getQuantity()).isEqualByComparingTo("50");
+        assertThat(found.get().getLocalPartyType()).isEqualTo(InterbankPartyType.BUYER);
+    }
+
+    @Test
+    @DisplayName("findBySourceNegotiationId — empty kad pregovor nije rezultovao ugovorom")
+    void lookupMissingContract() {
+        Optional<InterbankOtcContract> found = repository.findBySourceNegotiationId(999_999L);
+
+        assertThat(found).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findByLocalPartyIdAndLocalPartyRole — vraca sve ugovore za korisnika nezavisno od statusa")
+    void allContractsForUser() {
+        repository.save(buildBuyerSideContract(
+                1L, "AAPL", new BigDecimal("10"),
+                LocalDate.now().plusDays(10), InterbankOtcContractStatus.ACTIVE));
+        repository.save(buildBuyerSideContract(
+                2L, "MSFT", new BigDecimal("20"),
+                LocalDate.now().minusDays(5), InterbankOtcContractStatus.EXPIRED));
+        repository.save(buildBuyerSideContract(
+                3L, "GOOG", new BigDecimal("5"),
+                LocalDate.now().minusDays(15), InterbankOtcContractStatus.EXERCISED));
+        // Drugi korisnik — ne sme biti vracen
+        InterbankOtcContract other = buildBuyerSideContract(
+                4L, "TSLA", new BigDecimal("3"),
+                LocalDate.now().plusDays(7), InterbankOtcContractStatus.ACTIVE);
+        other.setLocalPartyId(8L);
+        repository.save(other);
+
+        List<InterbankOtcContract> mine = repository.findByLocalPartyIdAndLocalPartyRole(7L, "CLIENT");
+
+        assertThat(mine).hasSize(3);
+        assertThat(mine).extracting(InterbankOtcContract::getTicker)
+                .containsExactlyInAnyOrder("AAPL", "MSFT", "GOOG");
+    }
+
+    @Test
+    @DisplayName("findByLocalPartyTypeAndStatus — filtrira po BUYER/SELLER + status")
+    void filterByPartyAndStatus() {
+        // 2 BUYER ACTIVE
+        repository.save(buildBuyerSideContract(
+                1L, "AAPL", new BigDecimal("10"),
+                LocalDate.now().plusDays(10), InterbankOtcContractStatus.ACTIVE));
+        repository.save(buildBuyerSideContract(
+                2L, "MSFT", new BigDecimal("5"),
+                LocalDate.now().plusDays(15), InterbankOtcContractStatus.ACTIVE));
+        // 1 BUYER EXERCISED — ne sme biti vracen
+        repository.save(buildBuyerSideContract(
+                3L, "GOOG", new BigDecimal("8"),
+                LocalDate.now().minusDays(2), InterbankOtcContractStatus.EXERCISED));
+        // 1 SELLER ACTIVE — ne sme biti vracen
+        InterbankOtcContract sellerSide = buildBuyerSideContract(
+                4L, "TSLA", new BigDecimal("3"),
+                LocalDate.now().plusDays(20), InterbankOtcContractStatus.ACTIVE);
+        sellerSide.setLocalPartyType(InterbankPartyType.SELLER);
+        repository.save(sellerSide);
+
+        List<InterbankOtcContract> active = repository
+                .findByLocalPartyTypeAndStatus(InterbankPartyType.BUYER, InterbankOtcContractStatus.ACTIVE);
+
+        assertThat(active).hasSize(2);
+        assertThat(active).allMatch(c -> c.getStatus() == InterbankOtcContractStatus.ACTIVE);
+        assertThat(active).allMatch(c -> c.getLocalPartyType() == InterbankPartyType.BUYER);
+    }
+
+    @Test
+    @DisplayName("findByStatusAndSettlementDateBefore — auto-expiry helper za scheduler")
+    void autoExpiryHelper() {
+        LocalDate today = LocalDate.now();
+        // ACTIVE + settlement u proslosti → kandidat za expiry
+        repository.save(buildBuyerSideContract(
+                1L, "AAPL", new BigDecimal("10"),
+                today.minusDays(1), InterbankOtcContractStatus.ACTIVE));
+        repository.save(buildBuyerSideContract(
+                2L, "MSFT", new BigDecimal("5"),
+                today.minusDays(10), InterbankOtcContractStatus.ACTIVE));
+        // ACTIVE + settlement u buducnosti → NE kandidat
+        repository.save(buildBuyerSideContract(
+                3L, "GOOG", new BigDecimal("8"),
+                today.plusDays(5), InterbankOtcContractStatus.ACTIVE));
+        // EXPIRED — vec expirovan, ne kandidat (status filter)
+        repository.save(buildBuyerSideContract(
+                4L, "TSLA", new BigDecimal("3"),
+                today.minusDays(20), InterbankOtcContractStatus.EXPIRED));
+
+        List<InterbankOtcContract> toExpire = repository
+                .findByStatusAndSettlementDateBefore(InterbankOtcContractStatus.ACTIVE, today);
+
+        assertThat(toExpire).hasSize(2);
+        assertThat(toExpire).extracting(InterbankOtcContract::getTicker)
+                .containsExactlyInAnyOrder("AAPL", "MSFT");
+    }
+}

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/interbank/repository/InterbankOtcNegotiationRepositoryTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/interbank/repository/InterbankOtcNegotiationRepositoryTest.java
@@ -1,0 +1,183 @@
+package rs.raf.banka2_bek.interbank.repository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import rs.raf.banka2_bek.interbank.model.InterbankOtcNegotiation;
+import rs.raf.banka2_bek.interbank.model.InterbankOtcNegotiationStatus;
+import rs.raf.banka2_bek.interbank.model.InterbankPartyType;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * T12 — Integration test za InterbankOtcNegotiationRepository.
+ *
+ * Pokriva: persist + lookup po protokol-ID-ju, pretrage po lokalnoj strani,
+ * sumActiveAmountForSellerAndTicker (kvota check za §3.2 inbound).
+ *
+ * Profil "test" + H2 in-memory baza (vidi application-test.properties).
+ *
+ * NAPOMENA: Spring Boot 4 je uklonio @DataJpaTest iz default test-autoconfigure
+ * modula, pa koristimo @SpringBootTest. @Transactional osigurava rollback
+ * posle svakog testa (umesto rucnog deleteAll()).
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class InterbankOtcNegotiationRepositoryTest {
+
+    @Autowired
+    private InterbankOtcNegotiationRepository repository;
+
+    private InterbankOtcNegotiation buildSellerSideNegotiation(String foreignNegId, String ticker,
+                                                               BigDecimal amount,
+                                                               InterbankOtcNegotiationStatus status) {
+        // Mi smo SELLER (autoritativni vlasnik pregovora po §3.2). Foreign
+        // negotiation ID je generisan KOD NAS, pa je foreignNegotiationRoutingNumber
+        // = nas (222). Buyer je u banci 111.
+        InterbankOtcNegotiation n = new InterbankOtcNegotiation();
+        n.setForeignNegotiationRoutingNumber(222);
+        n.setForeignNegotiationIdString(foreignNegId);
+        n.setLocalPartyType(InterbankPartyType.SELLER);
+        n.setLocalPartyId(1L);
+        n.setLocalPartyRole("CLIENT");
+        n.setForeignPartyRoutingNumber(111);
+        n.setForeignPartyIdString("partner-buyer-001");
+        n.setTicker(ticker);
+        n.setAmount(amount);
+        n.setPricePerUnit(new BigDecimal("180.00"));
+        n.setPriceCurrency("USD");
+        n.setPremium(new BigDecimal("700.00"));
+        n.setPremiumCurrency("USD");
+        n.setSettlementDate(LocalDate.now().plusDays(30));
+        // Kupac je poslednji izmenio (inicirao pregovor) — turn je sad nas (seller).
+        n.setLastModifiedByRoutingNumber(111);
+        n.setLastModifiedByIdString("partner-buyer-001");
+        n.setStatus(status);
+        return n;
+    }
+
+    @BeforeEach
+    void cleanUp() {
+        // @Transactional na klasi obezbedjuje rollback per-test, ali
+        // application-test.properties ima ddl-auto=create -> baza moze
+        // perzistovati izmedju testova istog konteksta. Defensive cleanup.
+        repository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("save + findByForeignNegotiationRoutingNumberAndForeignNegotiationIdString — round-trip")
+    void persistAndLookupByForeignId() {
+        InterbankOtcNegotiation toSave = buildSellerSideNegotiation(
+                "neg-001", "AAPL", new BigDecimal("50.00"), InterbankOtcNegotiationStatus.ACTIVE);
+
+        InterbankOtcNegotiation saved = repository.save(toSave);
+
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getCreatedAt()).isNotNull();
+        assertThat(saved.getLastModifiedAt()).isNotNull();
+        // @PrePersist treba da postavi default ACTIVE ako nije bilo postavljeno.
+        assertThat(saved.getStatus()).isEqualTo(InterbankOtcNegotiationStatus.ACTIVE);
+
+        Optional<InterbankOtcNegotiation> found = repository
+                .findByForeignNegotiationRoutingNumberAndForeignNegotiationIdString(222, "neg-001");
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getTicker()).isEqualTo("AAPL");
+        assertThat(found.get().getAmount()).isEqualByComparingTo("50.00");
+        assertThat(found.get().getLocalPartyType()).isEqualTo(InterbankPartyType.SELLER);
+    }
+
+    @Test
+    @DisplayName("findBy...IdString — vraca empty kad ID ne postoji")
+    void lookupMissingNegotiation() {
+        Optional<InterbankOtcNegotiation> found = repository
+                .findByForeignNegotiationRoutingNumberAndForeignNegotiationIdString(222, "nepostojeci");
+
+        assertThat(found).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findByLocalPartyIdAndLocalPartyRoleAndStatus — filtrira po (id, role, status)")
+    void filterByLocalPartyAndStatus() {
+        repository.save(buildSellerSideNegotiation(
+                "neg-active-1", "AAPL", new BigDecimal("10"), InterbankOtcNegotiationStatus.ACTIVE));
+        repository.save(buildSellerSideNegotiation(
+                "neg-active-2", "AAPL", new BigDecimal("5"), InterbankOtcNegotiationStatus.ACTIVE));
+        // CLOSED — ne bi smeo biti vracen
+        repository.save(buildSellerSideNegotiation(
+                "neg-closed", "AAPL", new BigDecimal("3"), InterbankOtcNegotiationStatus.CLOSED));
+
+        List<InterbankOtcNegotiation> active = repository
+                .findByLocalPartyIdAndLocalPartyRoleAndStatus(1L, "CLIENT", InterbankOtcNegotiationStatus.ACTIVE);
+
+        assertThat(active).hasSize(2);
+        assertThat(active).allMatch(n -> n.getStatus() == InterbankOtcNegotiationStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("findByLocalPartyTypeAndStatus — filtrira po BUYER/SELLER")
+    void filterByPartyType() {
+        // 2 SELLER pregovora
+        repository.save(buildSellerSideNegotiation(
+                "neg-s1", "AAPL", new BigDecimal("10"), InterbankOtcNegotiationStatus.ACTIVE));
+        repository.save(buildSellerSideNegotiation(
+                "neg-s2", "AAPL", new BigDecimal("20"), InterbankOtcNegotiationStatus.ACTIVE));
+        // 1 BUYER pregovor
+        InterbankOtcNegotiation buyer = buildSellerSideNegotiation(
+                "neg-b1", "MSFT", new BigDecimal("15"), InterbankOtcNegotiationStatus.ACTIVE);
+        buyer.setLocalPartyType(InterbankPartyType.BUYER);
+        // BUYER varijanta: foreign negotiation ID generisan kod partner banke (111).
+        buyer.setForeignNegotiationRoutingNumber(111);
+        buyer.setForeignNegotiationIdString("partner-neg-b1");
+        repository.save(buyer);
+
+        List<InterbankOtcNegotiation> sellers = repository
+                .findByLocalPartyTypeAndStatus(InterbankPartyType.SELLER, InterbankOtcNegotiationStatus.ACTIVE);
+        List<InterbankOtcNegotiation> buyers = repository
+                .findByLocalPartyTypeAndStatus(InterbankPartyType.BUYER, InterbankOtcNegotiationStatus.ACTIVE);
+
+        assertThat(sellers).hasSize(2);
+        assertThat(buyers).hasSize(1);
+        assertThat(buyers.get(0).getTicker()).isEqualTo("MSFT");
+    }
+
+    @Test
+    @DisplayName("sumActiveAmountForSellerAndTicker — sumira ACTIVE pregovore za par (seller, ticker)")
+    void sumActiveAmountForSeller() {
+        // 2 ACTIVE pregovora za AAPL kod istog seller-a
+        repository.save(buildSellerSideNegotiation(
+                "neg-a1", "AAPL", new BigDecimal("30.00"), InterbankOtcNegotiationStatus.ACTIVE));
+        repository.save(buildSellerSideNegotiation(
+                "neg-a2", "AAPL", new BigDecimal("20.00"), InterbankOtcNegotiationStatus.ACTIVE));
+        // ACCEPTED — NE bi smeo biti uracunat (samo ACTIVE)
+        repository.save(buildSellerSideNegotiation(
+                "neg-a3", "AAPL", new BigDecimal("100.00"), InterbankOtcNegotiationStatus.ACCEPTED));
+        // Drugi ticker — NE bi smeo biti uracunat
+        repository.save(buildSellerSideNegotiation(
+                "neg-other", "MSFT", new BigDecimal("50.00"), InterbankOtcNegotiationStatus.ACTIVE));
+
+        BigDecimal sum = repository.sumActiveAmountForSellerAndTicker(1L, "CLIENT", "AAPL");
+
+        assertThat(sum).isCloseTo(new BigDecimal("50.00"), within(new BigDecimal("0.01")));
+    }
+
+    @Test
+    @DisplayName("sumActiveAmountForSellerAndTicker — vraca 0 kad nema pregovora (coalesce)")
+    void sumActiveAmountReturnsZeroWhenEmpty() {
+        BigDecimal sum = repository.sumActiveAmountForSellerAndTicker(999L, "CLIENT", "AAPL");
+
+        assertThat(sum).isNotNull();
+        assertThat(sum).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+}

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/investmentFund/service/InvestmentFundServicePositionsTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/investmentFund/service/InvestmentFundServicePositionsTest.java
@@ -1,0 +1,195 @@
+package rs.raf.banka2_bek.investmentFund.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import rs.raf.banka2_bek.client.model.Client;
+import rs.raf.banka2_bek.client.repository.ClientRepository;
+import rs.raf.banka2_bek.investmentfund.dto.InvestmentFundDtos.ClientFundPositionDto;
+import rs.raf.banka2_bek.investmentfund.model.ClientFundPosition;
+import rs.raf.banka2_bek.investmentfund.model.InvestmentFund;
+import rs.raf.banka2_bek.investmentfund.repository.ClientFundPositionRepository;
+import rs.raf.banka2_bek.investmentfund.repository.InvestmentFundRepository;
+import rs.raf.banka2_bek.investmentfund.service.InvestmentFundService;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * T12 — Mockito unit testovi za listMyPositions / listBankPositions.
+ *
+ * Spec ref:
+ *   - Celina 4 (Nova) "Moj portfolio -> Moji fondovi" (listMyPositions)
+ *   - Celina 4 (Nova) §4406-4435 Napomena 1+2 "Banka kao klijent fonda" (listBankPositions)
+ *   - Profit Banke "Pozicije u fondovima" tab (consumer od listBankPositions)
+ *
+ * Pokriva:
+ *   - happy path mapiranja u DTO
+ *   - prazni listovi (null parametri, prazna baza)
+ *   - email-based resolvovanje banka client_id-ja
+ *   - graceful fallback kad banka klijent nije seed-ovan
+ */
+@ExtendWith(MockitoExtension.class)
+class InvestmentFundServicePositionsTest {
+
+    @Mock
+    private InvestmentFundRepository investmentFundRepository;
+    @Mock
+    private ClientFundPositionRepository clientFundPositionRepository;
+    @Mock
+    private ClientRepository clientRepository;
+
+    @InjectMocks
+    private InvestmentFundService service;
+
+    private static final String BANK_EMAIL = "banka2.doo@banka.rs";
+
+    @BeforeEach
+    void setUp() {
+        // @Value se ne resolvuje sa MockitoExtension-om — koristimo
+        // ReflectionTestUtils da postavimo polje rucno. Inace bi
+        // bankOwnerClientEmail bio null i lookup bi se srusio.
+        ReflectionTestUtils.setField(service, "bankOwnerClientEmail", BANK_EMAIL);
+    }
+
+    private ClientFundPosition position(Long id, Long fundId, Long userId, String role, String invested) {
+        ClientFundPosition p = new ClientFundPosition();
+        p.setId(id);
+        p.setFundId(fundId);
+        p.setUserId(userId);
+        p.setUserRole(role);
+        p.setTotalInvested(new BigDecimal(invested));
+        p.setLastModifiedAt(LocalDateTime.now());
+        return p;
+    }
+
+    private InvestmentFund fund(Long id, String name) {
+        InvestmentFund f = new InvestmentFund();
+        f.setId(id);
+        f.setName(name);
+        return f;
+    }
+
+    // ─── listMyPositions ──────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("listMyPositions — vraca pozicije korisnika sa popunjenim fundName-om")
+    void listMyPositions_happyPath() {
+        ClientFundPosition p1 = position(101L, 1L, 5L, "CLIENT", "10000.00");
+        ClientFundPosition p2 = position(102L, 2L, 5L, "CLIENT", "25000.00");
+        when(clientFundPositionRepository.findByUserIdAndUserRole(5L, "CLIENT"))
+                .thenReturn(List.of(p1, p2));
+        when(investmentFundRepository.findAllById(any()))
+                .thenReturn(List.of(fund(1L, "Stable Income"), fund(2L, "Tech Growth")));
+
+        List<ClientFundPositionDto> result = service.listMyPositions(5L, "CLIENT");
+
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(ClientFundPositionDto::getFundName)
+                .containsExactlyInAnyOrder("Stable Income", "Tech Growth");
+        assertThat(result).extracting(ClientFundPositionDto::getUserId)
+                .containsOnly(5L);
+        assertThat(result).extracting(ClientFundPositionDto::getUserRole)
+                .containsOnly("CLIENT");
+        // Izvedena polja su jos uvek null (FundValueCalculator nije gotov u T12).
+        assertThat(result).allMatch(d -> d.getCurrentValue() == null
+                && d.getPercentOfFund() == null
+                && d.getProfit() == null);
+    }
+
+    @Test
+    @DisplayName("listMyPositions — vraca prazan list kad korisnik nema pozicija")
+    void listMyPositions_emptyForUserWithoutPositions() {
+        when(clientFundPositionRepository.findByUserIdAndUserRole(99L, "CLIENT"))
+                .thenReturn(List.of());
+
+        List<ClientFundPositionDto> result = service.listMyPositions(99L, "CLIENT");
+
+        assertThat(result).isEmpty();
+        // Ne sme zvati findAllById ako nema pozicija — fail fast.
+        verify(investmentFundRepository, never()).findAllById(any());
+    }
+
+    @Test
+    @DisplayName("listMyPositions — null userId vraca prazan list (defensive)")
+    void listMyPositions_nullUserId() {
+        List<ClientFundPositionDto> result = service.listMyPositions(null, "CLIENT");
+
+        assertThat(result).isEmpty();
+        verify(clientFundPositionRepository, never()).findByUserIdAndUserRole(any(), anyString());
+    }
+
+    @Test
+    @DisplayName("listMyPositions — blank userRole vraca prazan list (defensive)")
+    void listMyPositions_blankRole() {
+        List<ClientFundPositionDto> result = service.listMyPositions(5L, "  ");
+
+        assertThat(result).isEmpty();
+        verify(clientFundPositionRepository, never()).findByUserIdAndUserRole(any(), anyString());
+    }
+
+    // ─── listBankPositions ────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("listBankPositions — resolvuje banka client_id po email-u i vraca njegove pozicije")
+    void listBankPositions_happyPath() {
+        Client bankClient = new Client();
+        bankClient.setId(10L);
+        bankClient.setEmail(BANK_EMAIL);
+        when(clientRepository.findByEmail(BANK_EMAIL)).thenReturn(Optional.of(bankClient));
+
+        ClientFundPosition p = position(201L, 1L, 10L, "CLIENT", "250000.00");
+        when(clientFundPositionRepository.findByUserIdAndUserRole(10L, "CLIENT"))
+                .thenReturn(List.of(p));
+        when(investmentFundRepository.findAllById(any()))
+                .thenReturn(List.of(fund(1L, "Stable Income")));
+
+        List<ClientFundPositionDto> result = service.listBankPositions();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getFundName()).isEqualTo("Stable Income");
+        assertThat(result.get(0).getUserId()).isEqualTo(10L);
+        assertThat(result.get(0).getTotalInvested()).isEqualByComparingTo("250000.00");
+    }
+
+    @Test
+    @DisplayName("listBankPositions — graceful fallback kad bank client nije seed-ovan")
+    void listBankPositions_missingBankClient() {
+        when(clientRepository.findByEmail(BANK_EMAIL)).thenReturn(Optional.empty());
+
+        List<ClientFundPositionDto> result = service.listBankPositions();
+
+        assertThat(result).isEmpty();
+        // Ne sme dalje zvati pozicije ako banka klijent ne postoji.
+        verify(clientFundPositionRepository, never()).findByUserIdAndUserRole(any(), anyString());
+    }
+
+    @Test
+    @DisplayName("listBankPositions — vraca prazan list kad banka nema pozicija u fondovima")
+    void listBankPositions_bankExistsButNoPositions() {
+        Client bankClient = new Client();
+        bankClient.setId(10L);
+        when(clientRepository.findByEmail(BANK_EMAIL)).thenReturn(Optional.of(bankClient));
+        when(clientFundPositionRepository.findByUserIdAndUserRole(eq(10L), eq("CLIENT")))
+                .thenReturn(List.of());
+
+        List<ClientFundPositionDto> result = service.listBankPositions();
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/seed.sql
+++ b/seed.sql
@@ -2444,3 +2444,113 @@ VALUES
     (1006, 3, 'CLIENT', 4, 'CLIENT', 13, 1, 825.0000, 30.0000,
      (CURRENT_DATE - INTERVAL '5 days'), 'EXPIRED',
      (NOW() - INTERVAL '35 days'), NULL);
+
+-- ============================================================
+-- T12 — BANKA KAO KLIJENT FONDA + INVESTMENT FUND OWNER SEED
+-- ============================================================
+-- Spec ref:
+--   Celina 4 (Nova) §4406-4435 (Napomena 1+2 — banka investira preko
+--                                "vlasnik banke" klijenta)
+--   Celina 5 (Nova) — OTC inter-bank entiteti su odvojen sloj (vidi
+--                     interbank_otc_negotiations / interbank_otc_contracts)
+--
+-- Cilj:
+--   Da Profit Banke portala "Pozicije u fondovima" tab prikazuje prave
+--   podatke (ne prazan list). Banka se tretira kao obican klijent
+--   (userRole='CLIENT') sa svojim client_id-jem; svaka pozicija banke u
+--   fondu se evidentira u client_fund_positions sa userId = bankov client_id.
+--
+-- Idempotentnost:
+--   Svi INSERT-i koriste WHERE NOT EXISTS pa se mogu ponavljati pri
+--   re-seedu (Docker rebuild --no-cache + spring boot start).
+--
+-- IMPORTANT: ovaj blok mora ici NAKON sto Hibernate kreira:
+--   - clients          (vec postoji u prethodnom seedu)
+--   - investment_funds, client_fund_positions (Hibernate ddl-auto=update)
+-- ============================================================
+
+-- 1) Banka kao klijent (vlasnik banke) — Celina 4 (Nova) Napomena 1
+INSERT INTO clients (first_name, last_name, date_of_birth, gender, email, phone, address,
+                     password, salt_password, active, created_at)
+SELECT 'Banka 2', 'd.o.o.', '2025-01-01', 'OTHER', 'banka2.doo@banka.rs',
+       '+381 11 000 0000', 'Bulevar Kralja Aleksandra 73, Beograd',
+       '$2b$10$FUjcSzK7CZKeX53YVU4JjeOIXLt5axbipO85OlQqw5Dopg47zfgRG',
+       'c2VlZF9iYW5rYV9kb29f', 1, NOW()
+WHERE NOT EXISTS (
+    SELECT 1 FROM clients WHERE email = 'banka2.doo@banka.rs'
+);
+
+-- 2) Sample investment_funds — minimalan demo set tako da listBankPositions
+--    ima sta da vrati. Polja su:
+--      name, description, minimum_contribution, manager_employee_id,
+--      account_id, created_at, active, owner_client_id, inception_date
+--
+--    manager_employee_id  -> 1 (Marko Petrovic, admin/supervisor)
+--    account_id           -> 222000100000000110 (RSD bankin BANK_TRADING racun)
+--    owner_client_id      -> nas novi "Banka 2 d.o.o." klijent
+--
+--    Ako T7 (createFund) bude seed-ovao svoje fondove, ovi minimalni demo
+--    fondovi nece praviti konflikt jer imaju jedinstvena imena.
+INSERT INTO investment_funds (name, description, minimum_contribution, manager_employee_id,
+                               account_id, created_at, active, owner_client_id, inception_date)
+SELECT 'Banka 2 Stable Income', 'Konzervativni fond fokusiran na obveznice i blue-chip akcije.',
+       1000.0000, 1,
+       (SELECT id FROM accounts WHERE account_number = '222000100000000110'),
+       NOW(), 1,
+       (SELECT id FROM clients WHERE email = 'banka2.doo@banka.rs'),
+       (CURRENT_DATE - INTERVAL '180 days')
+WHERE EXISTS (SELECT 1 FROM accounts WHERE account_number = '222000100000000110')
+  AND NOT EXISTS (SELECT 1 FROM investment_funds WHERE name = 'Banka 2 Stable Income');
+
+INSERT INTO investment_funds (name, description, minimum_contribution, manager_employee_id,
+                               account_id, created_at, active, owner_client_id, inception_date)
+SELECT 'Banka 2 Tech Growth', 'Agresivan fond fokusiran na IT i tech sektor.',
+       5000.0000, 1,
+       (SELECT id FROM accounts WHERE account_number = '222000100000000110'),
+       NOW(), 1,
+       (SELECT id FROM clients WHERE email = 'banka2.doo@banka.rs'),
+       (CURRENT_DATE - INTERVAL '90 days')
+WHERE EXISTS (SELECT 1 FROM accounts WHERE account_number = '222000100000000110')
+  AND NOT EXISTS (SELECT 1 FROM investment_funds WHERE name = 'Banka 2 Tech Growth');
+
+-- 3) Backfill owner_client_id za SVE postojece fondove (po §4406-4435):
+--    Ako fond nema postavljen vlasnika (npr. T7 jos nije pozvao
+--    createFund sa owner_client_id parametrom), default-ujemo na "Banka 2
+--    d.o.o." klijenta. Ovo cini listBankPositions deterministicki rad
+--    cak i za fondove kreirane pre uvoda owner_client_id polja.
+UPDATE investment_funds
+SET owner_client_id = (SELECT id FROM clients WHERE email = 'banka2.doo@banka.rs')
+WHERE owner_client_id IS NULL;
+
+-- 4) Sample bankine pozicije u fondovima — Celina 4 (Nova) Napomena 2:
+--    "ClientFundPosition za banku: Klijent je klijent koji je vlasnik banke."
+--    userRole = 'CLIENT', userId = banka2.doo client_id
+INSERT INTO client_fund_positions (fund_id, user_id, user_role, total_invested, last_modified_at)
+SELECT f.id,
+       (SELECT id FROM clients WHERE email = 'banka2.doo@banka.rs'),
+       'CLIENT',
+       250000.0000,
+       NOW()
+FROM investment_funds f
+WHERE f.name = 'Banka 2 Stable Income'
+  AND NOT EXISTS (
+      SELECT 1 FROM client_fund_positions p
+      WHERE p.fund_id = f.id
+        AND p.user_id = (SELECT id FROM clients WHERE email = 'banka2.doo@banka.rs')
+        AND p.user_role = 'CLIENT'
+  );
+
+INSERT INTO client_fund_positions (fund_id, user_id, user_role, total_invested, last_modified_at)
+SELECT f.id,
+       (SELECT id FROM clients WHERE email = 'banka2.doo@banka.rs'),
+       'CLIENT',
+       500000.0000,
+       NOW()
+FROM investment_funds f
+WHERE f.name = 'Banka 2 Tech Growth'
+  AND NOT EXISTS (
+      SELECT 1 FROM client_fund_positions p
+      WHERE p.fund_id = f.id
+        AND p.user_id = (SELECT id FROM clients WHERE email = 'banka2.doo@banka.rs')
+        AND p.user_role = 'CLIENT'
+  );


### PR DESCRIPTION
## T12 — Inter-bank OTC entiteti + Banka kao klijent fonda + listMy/BankPositions

Closes #61 

### Šta je urađeno

**1) Novi inter-bank OTC entiteti (Protokol §2.3 + §3, Celina 5 (Nova))**

Postojeći intra-bank `otc/model/OtcOffer` i `OtcContract` čuvaju strane kao `Long` (ka lokalnim klijentima/zaposlenima) i nisu prikladni za inter-bank pregovore u kojima je druga strana opaque kompozitni `ForeignBankId{routingNumber, idString}`. Zato su uvedena **dva nova entiteta**:

- `interbank/model/InterbankOtcNegotiation.java`
  - kompozitni `foreignNegotiationRoutingNumber + foreignNegotiationIdString` (UNIQUE — brzi lookup po protokol-formi po §3.2/3.3/3.4)
  - `localPartyType` (BUYER/SELLER), `localPartyId/Role` — naša strana
  - `foreignPartyRoutingNumber + foreignPartyIdString` — strana strana (opaque, ne interpretiramo)
  - ticker, amount, pricePerUnit, premium, settlementDate (BigDecimal po §2.5)
  - `lastModifiedByRoutingNumber + idString` za pravilo turne (§3.3)
  - `ongoing` boolean (preslikava §3.4 OtcNegotiation shape) + status enum
- `interbank/model/InterbankOtcContract.java`
  - `sourceNegotiationId` (FK ka pregovoru)
  - lokalna strana + foreign strana, strikePrice, premium, settlementDate, status, exercisedAt
- Prateći enumi: `InterbankPartyType` (BUYER/SELLER), `InterbankOtcNegotiationStatus` (ACTIVE/ACCEPTED/DECLINED/CLOSED), `InterbankOtcContractStatus` (ACTIVE/EXERCISED/EXPIRED)

**2) Repozitorijumi**

- `InterbankOtcNegotiationRepository`:
  - `findByForeignNegotiationRoutingNumberAndForeignNegotiationIdString` — primarni lookup za PUT/GET/DELETE/accept handler-e (T2/T3)
  - `findByLocalPartyIdAndLocalPartyRoleAndStatus` — "Aktivne ponude" tab
  - `findByLocalPartyTypeAndStatus` — supervisor view
  - `sumActiveAmountForSellerAndTicker` — kvota check za §3.2 inbound (sa COALESCE 0 da nikad ne vraća null)
- `InterbankOtcContractRepository`:
  - `findBySourceNegotiationId` — 1:1 mapiranje pregovor→ugovor
  - `findByLocalPartyIdAndLocalPartyRole`, `findByLocalPartyTypeAndStatus`
  - `findByStatusAndSettlementDateBefore` — auto-expiry helper za scheduler (§2.7.2 "if not used, resources shall be un-reserved")

**3) seed.sql — Banka kao klijent (Celina 4 (Nova) §4406-4435 Napomena 1+2)**

Idempotentni seed (sve preko `WHERE NOT EXISTS`):
- novi klijent `Banka 2 d.o.o.` (email `banka2.doo@banka.rs`)
- 2 sample fonda (`Banka 2 Stable Income`, `Banka 2 Tech Growth`) sa `owner_client_id` → bank client
- backfill `UPDATE investment_funds SET owner_client_id = ... WHERE owner_client_id IS NULL` — bezbedan i za fondove koje T7 kreira preko `createFund` API-ja
- 2 sample `client_fund_positions` sa `userRole='CLIENT'` i `userId = bank client_id` da Profit Banke "Pozicije u fondovima" tab odmah ima nešto da prikaže

**4) `InvestmentFundService` — `listMyPositions` + `listBankPositions`**

- `listMyPositions(Long userId, String userRole)`:
  - vraća pozicije ulogovanog korisnika sa popunjenim `fundName`-om (batch-load fondova → bez N+1)
  - defensive null/blank check vraća prazan list
  - izvedena polja (`currentValue`, `percentOfFund`, `profit`) ostaju `null` — biće dopunjena kad T7+T10 završe `FundValueCalculator`
- `listBankPositions()`:
  - resolvuje banka client_id po email-u iz `bank.owner-client-email` propertyja → reuse `listMyPositions(bankClientId, "CLIENT")`
  - **graceful fallback**: ako banka klijent nije seed-ovan, vraća prazan list + warn log umesto 500-ke (Profit Banke FE renderuje "Banka nema pozicije" placeholder)
  - email-based lookup umesto fixed ID-ja jer je `clients.id` AUTO_INCREMENT — ne možemo ga forsirati u seedu bez konflikta
- `application.properties`: dodat `bank.owner-client-email=banka2.doo@banka.rs`

### Definicija Gotovog

- [x] Hibernate kreira nove tabele (`interbank_otc_negotiations`, `interbank_otc_contracts`) — verifikovano kroz `@SpringBootTest` koji pokreće `ddl-auto=create` na H2
- [x] Seed prošao u Docker rebuild-u, `Banka 2 d.o.o.` postoji u `clients` tabeli — INSERT je idempotentan
- [x] Profit Banke "Pozicije u fondovima" tab počinje da prikazuje prave podatke (ne prazan list) — `ProfitBankController.fundPositions()` poziva `listBankPositions()` koji sad vraća stvarne entitete
- [x] Unit testovi za repos

### Testovi

| Test                                          | Tests | Status |
|-----------------------------------------------|-------|--------|
| `InterbankOtcNegotiationRepositoryTest`       | 6     | PASS   |
| `InterbankOtcContractRepositoryTest`          | 5     | PASS   |
| `InvestmentFundServicePositionsTest`          | 7     | PASS   |
| **Full suite** (regression check)             | 2262  | PASS (0 failures, 0 errors) |

### Koordinacija

- **T2 (OTC outbound)** i **T3 (OTC inbound)** mogu odmah da koriste `InterbankOtcNegotiationRepository` i `InterbankOtcContractRepository` za persist. TODO blok iznad `OtcNegotiationService` već referencira ova polja.
- **T7 (createFund)** — `seed.sql` UPDATE statement je idempotentan; ako T7 doda svoje fondove preko API-ja, oni će automatski dobiti `owner_client_id` banke (osim ako T7 eksplicitno postavi drugi vlasnik).
- **T8 (FE)** — može odmah da konzumira `GET /funds/my-positions` i `GET /profit-bank/fund-positions`.
- **T10 (FundValueCalculator)** — kad bude gotov, dopuniti `InvestmentFundService.toClientFundPositionDto` da popuni `currentValue/percentOfFund/profit` umesto `null`.

### Napomene

- Inter-bank entiteti su **odvojeni sloj** od intra-bank `otc/model/*` (namene su različite, mešanje bi pokvarilo postojeći flow). Niko ne dira intra-bank kod.
- `InterbankOtcNegotiation.ongoing` je redundantan sa `status = ACTIVE`, ali se čuva kao odvojena kolona da odgovor `GET /negotiations/{rn}/{id}` može direktno da preslika protokolni `OtcNegotiation` shape (§3.4) bez enum mapiranja.

### Test plan

- [x] `mvn compile` čisto
- [x] `mvn test` — 2262/2262 PASS
- [ ] Docker rebuild + manual probe: `GET /profit-bank/fund-positions` vraća 2 reda (Stable Income + Tech Growth)
- [ ] Docker rebuild + manual probe: `GET /funds/my-positions` kao Stefan vraća prazan list (Stefan nema pozicija u seedu — proveriti negativan slučaj)