### PR TITLE
nadogradnja T1 taska: integracioni test za TransactionExecutorService (execute) + pseudo-account verifikaciono pravilo

### DIFF
--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/controller/InterbankInboundController.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/controller/InterbankInboundController.java
@@ -66,9 +66,6 @@ public class InterbankInboundController {
     private final InterbankMessageService interbankMessageService;
     private final TransactionExecutorService transactionExecutorService;
 
-    // TODO: injectovati TransactionExecutorService, InterbankMessageService,
-    //   BankRoutingService, ObjectMapper
-
     /**
      * Glavni endpoint po §2.11. Body je Message<Type> envelope sa
      * idempotenceKey + messageType + message (Transaction / CommitTransaction
@@ -111,21 +108,6 @@ public class InterbankInboundController {
             return ResponseEntity.ok(objectMapper.readTree(cashedOpt.get()));
 
         return ResponseEntity.noContent().build();
-
-
-        // TODO:
-        //  1. §2.10 — provera X-Api-Key + envelope.idempotenceKey.routingNumber
-        //  2. §2.2 — InterbankMessageService.findCachedResponse → return cache hit
-        //  3. §2.12 dispatch po envelope.messageType:
-        //     case NEW_TX:      cast envelope.message → Transaction →
-        //                       TransactionExecutorService.handleNewTx
-        //                       → TransactionVote → 200
-        //     case COMMIT_TX:   cast → CommitTransaction →
-        //                       TransactionExecutorService.handleCommitTx → 204
-        //     case ROLLBACK_TX: cast → RollbackTransaction →
-        //                       TransactionExecutorService.handleRollbackTx → 204
-        //  4. Atomicno sa biznis logikom: InterbankMessageService.recordInboundResponse
-        //  5. Network/IO greske -> 500; biznis -> 200 sa NO glasom (ne 5xx)
 
     }
 

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/controller/InterbankInboundController.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/controller/InterbankInboundController.java
@@ -108,7 +108,7 @@ public class InterbankInboundController {
             return dispatchByMessageType(messageType, idempotenceKey, messageNode);
 
         if (!cashedOpt.get().isBlank())
-            return ResponseEntity.status(200).body(cashedOpt.get());
+            return ResponseEntity.ok(objectMapper.readTree(cashedOpt.get()));
 
         return ResponseEntity.noContent().build();
 

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/service/InterbankReservationApplier.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/service/InterbankReservationApplier.java
@@ -8,6 +8,7 @@ import rs.raf.banka2_bek.account.repository.AccountRepository;
 import rs.raf.banka2_bek.interbank.exception.InterbankExceptions;
 import rs.raf.banka2_bek.portfolio.model.Portfolio;
 import rs.raf.banka2_bek.portfolio.repository.PortfolioRepository;
+import rs.raf.banka2_bek.stock.model.Listing;
 
 import java.math.BigDecimal;
 import java.util.Optional;
@@ -88,9 +89,9 @@ public class InterbankReservationApplier {
         portfolioRepository.save(portfolio);
     }
 
-    public void commitStock(Long userId, String role, Long listingId, int quantity, boolean isDebit){
+    public void commitStock(Long userId, String role, Listing listing, int quantity, boolean isDebit){
         if (isDebit) {
-            Optional<Portfolio> current = portfolioRepository.findByUserIdAndUserRoleAndListingIdForUpdate(userId, role, listingId);
+            Optional<Portfolio> current = portfolioRepository.findByUserIdAndUserRoleAndListingIdForUpdate(userId, role, listing.getId());
             if (current.isPresent()) {
                 Portfolio portfolio = current.get();
                 portfolio.setQuantity(portfolio.getQuantity() + quantity);
@@ -99,7 +100,11 @@ public class InterbankReservationApplier {
                 Portfolio portfolio = Portfolio.builder()
                         .userId(userId)
                         .userRole(role)
-                        .listingId(listingId)
+                        .listingId(listing.getId())
+                        .listingTicker(listing.getTicker())
+                        .listingName(listing.getName())
+                        .listingType(listing.getListingType().name())
+                        .averageBuyPrice(listing.getPrice() != null ? listing.getPrice() : BigDecimal.ZERO)
                         .quantity(quantity)
                         .reservedQuantity(0)
                         .publicQuantity(0)
@@ -108,9 +113,9 @@ public class InterbankReservationApplier {
             }
         }
         else {
-            Portfolio portfolio = portfolioRepository.findByUserIdAndUserRoleAndListingIdForUpdate(userId, role, listingId)
+            Portfolio portfolio = portfolioRepository.findByUserIdAndUserRoleAndListingIdForUpdate(userId, role, listing.getId())
                   .orElseThrow(
-                          () -> new InterbankExceptions.InterbankProtocolException("NO_SUCH_ASSET: no portfolio exists for listing " + listingId)
+                          () -> new InterbankExceptions.InterbankProtocolException("NO_SUCH_ASSET: no portfolio exists for listing " + listing.getId())
                   );
             portfolio.setQuantity(portfolio.getQuantity() - quantity);
             portfolio.setReservedQuantity(Math.max(0, portfolio.getReservedQuantity() - quantity));

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/service/TransactionExecutorService.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/service/TransactionExecutorService.java
@@ -11,9 +11,13 @@ import rs.raf.banka2_bek.account.model.Account;
 import rs.raf.banka2_bek.account.model.AccountStatus;
 import rs.raf.banka2_bek.account.repository.AccountRepository;
 import rs.raf.banka2_bek.interbank.exception.InterbankExceptions;
+import rs.raf.banka2_bek.interbank.model.InterbankOtcContract;
+import rs.raf.banka2_bek.interbank.model.InterbankOtcNegotiation;
 import rs.raf.banka2_bek.interbank.model.InterbankTransaction;
 import rs.raf.banka2_bek.interbank.model.InterbankTransactionStatus;
 import rs.raf.banka2_bek.interbank.protocol.*;
+import rs.raf.banka2_bek.interbank.repository.InterbankOtcContractRepository;
+import rs.raf.banka2_bek.interbank.repository.InterbankOtcNegotiationRepository;
 import rs.raf.banka2_bek.interbank.repository.InterbankTransactionRepository;
 import rs.raf.banka2_bek.portfolio.model.Portfolio;
 import rs.raf.banka2_bek.portfolio.repository.PortfolioRepository;
@@ -38,6 +42,8 @@ public class TransactionExecutorService {
     private final PortfolioRepository portfolioRepository;
     private final InterbankReservationApplier reservationApplier;
     private final ListingRepository listingRepository;
+    private final InterbankOtcNegotiationRepository otcNegotiationRepository;
+    private final InterbankOtcContractRepository otcContractRepository;
 
     /**
      * §2.8.5: self-proxy so that @Transactional on phase methods is respected when called
@@ -586,8 +592,21 @@ public class TransactionExecutorService {
                     }
                 }
 
-            } else if (asset instanceof Asset.OptionAsset) {
-                violations.add(new NoVoteReason(NoVoteReason.Reason.OPTION_NEGOTIATION_NOT_FOUND, p));
+            } else if (asset instanceof Asset.OptionAsset opAsset && account instanceof TxAccount.Option op) {
+                OptionDescription optionDescription = opAsset.asset();
+                ForeignBankId negotiationId = optionDescription.negotiationId();
+
+                Optional<InterbankOtcNegotiation> negotiationOptional = otcNegotiationRepository.findByForeignNegotiationRoutingNumberAndForeignNegotiationIdString(negotiationId.routingNumber(), negotiationId.id());
+
+                if (negotiationOptional.isEmpty()) {
+                    violations.add(new NoVoteReason(NoVoteReason.Reason.OPTION_NEGOTIATION_NOT_FOUND, p));
+                }
+
+
+
+                //b2b protocol 2.8.6 - pravilo 5
+
+                //b2b protocol 2.8.6 - pravilo 6
 
             } else {
                 violations.add(new NoVoteReason(NoVoteReason.Reason.UNACCEPTABLE_ASSET, p));

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/service/TransactionExecutorService.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/service/TransactionExecutorService.java
@@ -12,6 +12,7 @@ import rs.raf.banka2_bek.account.model.AccountStatus;
 import rs.raf.banka2_bek.account.repository.AccountRepository;
 import rs.raf.banka2_bek.interbank.exception.InterbankExceptions;
 import rs.raf.banka2_bek.interbank.model.InterbankOtcContract;
+import rs.raf.banka2_bek.interbank.model.InterbankOtcContractStatus;
 import rs.raf.banka2_bek.interbank.model.InterbankOtcNegotiation;
 import rs.raf.banka2_bek.interbank.model.InterbankTransaction;
 import rs.raf.banka2_bek.interbank.model.InterbankTransactionStatus;
@@ -26,6 +27,7 @@ import rs.raf.banka2_bek.stock.repository.ListingRepository;
 
 import java.math.BigDecimal;
 import java.security.SecureRandom;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.*;
 
@@ -247,8 +249,20 @@ public class TransactionExecutorService {
                 Long userId = Long.parseLong(pe.id().id());
                 reservationApplier.commitStock(userId, "CLIENT", listing,
                         abs.intValueExact(), isDebit);
+
+            } else if (p.asset() instanceof Asset.OptionAsset oa && p.account() instanceof TxAccount.Option) {
+                ForeignBankId negId = oa.asset().negotiationId();
+                otcNegotiationRepository
+                        .findByForeignNegotiationRoutingNumberAndForeignNegotiationIdString(
+                                negId.routingNumber(), negId.id())
+                        .ifPresent(neg ->
+                                otcContractRepository.findBySourceNegotiationId(neg.getId())
+                                        .ifPresent(contract -> {
+                                            contract.setStatus(InterbankOtcContractStatus.EXERCISED);
+                                            contract.setExercisedAt(LocalDateTime.now());
+                                            otcContractRepository.save(contract);
+                                        }));
             }
-            // OptionAsset: no-op for T1
         }
 
         ibTx.setStatus(InterbankTransactionStatus.COMMITTED);
@@ -290,6 +304,10 @@ public class TransactionExecutorService {
                                 "Listing not found: " + s.asset().ticker()));
                 Long userId = Long.parseLong(pe.id().id());
                 reservationApplier.releaseStock(userId, "CLIENT", listing.getId(), abs.intValueExact());
+
+            } else if (p.asset() instanceof Asset.OptionAsset) {
+                // Option rollback is a no-op: stocks remain reserved under the contract;
+                // the contract stays ACTIVE so the buyer can retry.
             }
         }
 
@@ -592,21 +610,50 @@ public class TransactionExecutorService {
                     }
                 }
 
-            } else if (asset instanceof Asset.OptionAsset opAsset && account instanceof TxAccount.Option op) {
+            } else if (asset instanceof Asset.OptionAsset opAsset && account instanceof TxAccount.Option) {
                 OptionDescription optionDescription = opAsset.asset();
                 ForeignBankId negotiationId = optionDescription.negotiationId();
 
-                Optional<InterbankOtcNegotiation> negotiationOptional = otcNegotiationRepository.findByForeignNegotiationRoutingNumberAndForeignNegotiationIdString(negotiationId.routingNumber(), negotiationId.id());
-
+                Optional<InterbankOtcNegotiation> negotiationOptional =
+                        otcNegotiationRepository.findByForeignNegotiationRoutingNumberAndForeignNegotiationIdString(
+                                negotiationId.routingNumber(), negotiationId.id());
                 if (negotiationOptional.isEmpty()) {
                     violations.add(new NoVoteReason(NoVoteReason.Reason.OPTION_NEGOTIATION_NOT_FOUND, p));
+                    continue;
                 }
 
+                Optional<InterbankOtcContract> contractOptional =
+                        otcContractRepository.findBySourceNegotiationId(negotiationOptional.get().getId());
+                if (contractOptional.isEmpty()) {
+                    violations.add(new NoVoteReason(NoVoteReason.Reason.OPTION_NEGOTIATION_NOT_FOUND, p));
+                    continue;
+                }
 
+                InterbankOtcContract contract = contractOptional.get();
 
-                //b2b protocol 2.8.6 - pravilo 5
+                // §2.8.6 rule 5: option must not be used or expired
+                if (contract.getStatus() != InterbankOtcContractStatus.ACTIVE
+                        || contract.getSettlementDate().isBefore(LocalDate.now())) {
+                    violations.add(new NoVoteReason(NoVoteReason.Reason.OPTION_USED_OR_EXPIRED, p));
+                    continue;
+                }
 
-                //b2b protocol 2.8.6 - pravilo 6
+                // §2.8.6 rule 6: companion postings must match contract terms exactly
+                BigDecimal requiredMoney = contract.getQuantity().multiply(contract.getStrikePrice());
+
+                boolean stockOk = tx.postings().stream().anyMatch(sp ->
+                        sp.asset() instanceof Asset.Stock ss
+                        && ss.asset().ticker().equals(contract.getTicker())
+                        && sp.amount().abs().compareTo(contract.getQuantity()) == 0);
+
+                boolean moneyOk = tx.postings().stream().anyMatch(mp ->
+                        mp.asset() instanceof Asset.Monas mm
+                        && mm.asset().currency().name().equals(contract.getStrikeCurrency())
+                        && mp.amount().abs().compareTo(requiredMoney) == 0);
+
+                if (!stockOk || !moneyOk) {
+                    violations.add(new NoVoteReason(NoVoteReason.Reason.OPTION_AMOUNT_INCORRECT, p));
+                }
 
             } else {
                 violations.add(new NoVoteReason(NoVoteReason.Reason.UNACCEPTABLE_ASSET, p));

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/service/TransactionExecutorService.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/interbank/service/TransactionExecutorService.java
@@ -15,7 +15,6 @@ import rs.raf.banka2_bek.interbank.model.InterbankTransaction;
 import rs.raf.banka2_bek.interbank.model.InterbankTransactionStatus;
 import rs.raf.banka2_bek.interbank.protocol.*;
 import rs.raf.banka2_bek.interbank.repository.InterbankTransactionRepository;
-import rs.raf.banka2_bek.order.service.CurrencyConversionService;
 import rs.raf.banka2_bek.portfolio.model.Portfolio;
 import rs.raf.banka2_bek.portfolio.repository.PortfolioRepository;
 import rs.raf.banka2_bek.stock.model.Listing;
@@ -39,7 +38,6 @@ public class TransactionExecutorService {
     private final PortfolioRepository portfolioRepository;
     private final InterbankReservationApplier reservationApplier;
     private final ListingRepository listingRepository;
-    private final CurrencyConversionService currencyConversionService;
 
     /**
      * §2.8.5: self-proxy so that @Transactional on phase methods is respected when called
@@ -125,6 +123,8 @@ public class TransactionExecutorService {
 
         List<NoVoteReason> violations = doValidateAndReserve(tx);
         if (!violations.isEmpty()) {
+            updateTransactionStatus(tx.transactionId(), InterbankTransactionStatus.ROLLED_BACK,
+                    "Local validation failed: " + violations);
             return new Phase1Result(
                     new TransactionVote(TransactionVote.Vote.NO, violations),
                     Map.of(), Map.of());
@@ -231,21 +231,15 @@ public class TransactionExecutorService {
             boolean isDebit = p.amount().compareTo(BigDecimal.ZERO) > 0;
             BigDecimal abs = p.amount().abs();
 
-            if (p.asset() instanceof Asset.Monas m && p.account() instanceof TxAccount.Account a) {
-                Account acct = accountRepository.findForUpdateByAccountNumber(a.num())
-                        .orElseThrow(() -> new InterbankExceptions.InterbankProtocolException(
-                                "Account not found: " + a.num()));
-                String fromCcy = m.asset().currency().name();
-                String toCcy = acct.getCurrency().getCode();
-                BigDecimal converted = currencyConversionService.convert(abs, fromCcy, toCcy);
-                reservationApplier.commitMonas(a.num(), converted, isDebit);
+            if (p.asset() instanceof Asset.Monas && p.account() instanceof TxAccount.Account a) {
+                reservationApplier.commitMonas(a.num(), abs, isDebit);
 
             } else if (p.asset() instanceof Asset.Stock s && p.account() instanceof TxAccount.Person pe) {
                 Listing listing = listingRepository.findByTicker(s.asset().ticker())
                         .orElseThrow(() -> new InterbankExceptions.InterbankProtocolException(
                                 "Listing not found: " + s.asset().ticker()));
                 Long userId = Long.parseLong(pe.id().id());
-                reservationApplier.commitStock(userId, "CLIENT", listing.getId(),
+                reservationApplier.commitStock(userId, "CLIENT", listing,
                         abs.intValueExact(), isDebit);
             }
             // OptionAsset: no-op for T1
@@ -281,14 +275,8 @@ public class TransactionExecutorService {
 
             BigDecimal abs = p.amount().abs();
 
-            if (p.asset() instanceof Asset.Monas m && p.account() instanceof TxAccount.Account a) {
-                Account acct = accountRepository.findForUpdateByAccountNumber(a.num())
-                        .orElseThrow(() -> new InterbankExceptions.InterbankProtocolException(
-                                "Account not found: " + a.num()));
-                String fromCcy = m.asset().currency().name();
-                String toCcy = acct.getCurrency().getCode();
-                BigDecimal converted = currencyConversionService.convert(abs, fromCcy, toCcy);
-                reservationApplier.releaseMonas(a.num(), converted);
+            if (p.asset() instanceof Asset.Monas && p.account() instanceof TxAccount.Account a) {
+                reservationApplier.releaseMonas(a.num(), abs);
 
             } else if (p.asset() instanceof Asset.Stock s && p.account() instanceof TxAccount.Person pe) {
                 Listing listing = listingRepository.findByTicker(s.asset().ticker())
@@ -451,6 +439,10 @@ public class TransactionExecutorService {
     }
 
     private void saveCoordinatorState(Transaction tx, InterbankTransactionStatus status) {
+        if (txRepo.findByTransactionRoutingNumberAndTransactionIdString(
+                tx.transactionId().routingNumber(), tx.transactionId().id()).isPresent()) {
+            return;
+        }
         try {
             InterbankTransaction ibt = new InterbankTransaction();
             ibt.setTransactionRoutingNumber(tx.transactionId().routingNumber());
@@ -470,6 +462,10 @@ public class TransactionExecutorService {
     }
 
     private void saveRecipientState(Transaction tx) {
+        if (txRepo.findByTransactionRoutingNumberAndTransactionIdString(
+                tx.transactionId().routingNumber(), tx.transactionId().id()).isPresent()) {
+            return;
+        }
         try {
             InterbankTransaction ibt = new InterbankTransaction();
             ibt.setTransactionRoutingNumber(tx.transactionId().routingNumber());
@@ -500,6 +496,13 @@ public class TransactionExecutorService {
                 });
     }
 
+    private static String assetKey(Asset asset) {
+        if (asset instanceof Asset.Monas m)      return "MONAS:" + m.asset().currency().name();
+        if (asset instanceof Asset.Stock s)       return "STOCK:" + s.asset().ticker();
+        if (asset instanceof Asset.OptionAsset o) return "OPTION:" + o.asset().negotiationId().id();
+        return "UNKNOWN:" + asset.getClass().getSimpleName();
+    }
+
     private boolean isPostingRemote(Posting p) {
         TxAccount account = p.account();
         if (account instanceof TxAccount.Account a) {
@@ -518,11 +521,14 @@ public class TransactionExecutorService {
      * Pass 2: make reservations only if Pass 1 found no violations.
      */
     private List<NoVoteReason> doValidateAndReserve(Transaction tx) {
-        BigDecimal sum = tx.postings().stream()
-                .map(Posting::amount)
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
-        if (sum.compareTo(BigDecimal.ZERO) != 0) {
-            return List.of(new NoVoteReason(NoVoteReason.Reason.UNBALANCED_TX, null));
+        Map<String, BigDecimal> assetSums = new LinkedHashMap<>();
+        for (Posting p : tx.postings()) {
+            assetSums.merge(assetKey(p.asset()), p.amount(), BigDecimal::add);
+        }
+        for (BigDecimal groupSum : assetSums.values()) {
+            if (groupSum.compareTo(BigDecimal.ZERO) != 0) {
+                return List.of(new NoVoteReason(NoVoteReason.Reason.UNBALANCED_TX, null));
+            }
         }
 
         List<NoVoteReason> violations = new ArrayList<>();
@@ -570,7 +576,7 @@ public class TransactionExecutorService {
                 if (isCredit) {
                     Listing listing = listingOpt.get();
                     Optional<Portfolio> portfolioOpt = portfolioRepository
-                            .findByUserIdAndUserRoleAndListingIdForUpdate(userId, "CLIENT", listing.getId());
+                            .findByUserIdAndUserRoleAndListingId(userId, "CLIENT", listing.getId());
                     if (portfolioOpt.isEmpty()) {
                         violations.add(new NoVoteReason(NoVoteReason.Reason.NO_SUCH_ASSET, p));
                         continue;

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/portfolio/repository/PortfolioRepository.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/portfolio/repository/PortfolioRepository.java
@@ -32,6 +32,8 @@ public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
     @Query("SELECT p FROM Portfolio p WHERE p.id = :id")
     Optional<Portfolio> findByIdForUpdate(@Param("id") Long id);
 
+    Optional<Portfolio> findByUserIdAndUserRoleAndListingId(Long userId, String userRole, Long listingId);
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT p FROM Portfolio p WHERE p.userId = :userId AND p.userRole = :userRole AND p.listingId = :listingId")
     Optional<Portfolio> findByUserIdAndUserRoleAndListingIdForUpdate(@Param("userId") Long userId,

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/interbank/service/InterbankTwoPhaseCommitIT.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/interbank/service/InterbankTwoPhaseCommitIT.java
@@ -1,0 +1,278 @@
+package rs.raf.banka2_bek.interbank.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import rs.raf.banka2_bek.IntegrationTestCleanup;
+import rs.raf.banka2_bek.TestObjectMapperConfig;
+import rs.raf.banka2_bek.account.model.Account;
+import rs.raf.banka2_bek.account.model.AccountStatus;
+import rs.raf.banka2_bek.account.model.AccountType;
+import rs.raf.banka2_bek.account.repository.AccountRepository;
+import rs.raf.banka2_bek.client.model.Client;
+import rs.raf.banka2_bek.client.repository.ClientRepository;
+import rs.raf.banka2_bek.currency.model.Currency;
+import rs.raf.banka2_bek.currency.repository.CurrencyRepository;
+import rs.raf.banka2_bek.employee.model.Employee;
+import rs.raf.banka2_bek.employee.repository.EmployeeRepository;
+import rs.raf.banka2_bek.interbank.model.InterbankMessage;
+import rs.raf.banka2_bek.interbank.model.InterbankMessageStatus;
+import rs.raf.banka2_bek.interbank.model.InterbankTransaction;
+import rs.raf.banka2_bek.interbank.model.InterbankTransactionStatus;
+import rs.raf.banka2_bek.interbank.protocol.*;
+import rs.raf.banka2_bek.interbank.repository.InterbankMessageRepository;
+import rs.raf.banka2_bek.interbank.repository.InterbankTransactionRepository;
+
+import javax.sql.DataSource;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * §2.8.5 Integration test: 2PC flow with real @Transactional boundaries and H2.
+ * InterbankClient is mocked to simulate partner bank responses.
+ */
+@Import(TestObjectMapperConfig.class)
+@SpringBootTest
+@ActiveProfiles("test")
+class InterbankTwoPhaseCommitIT {
+
+    private static final int MY_RN     = 222;
+    private static final int REMOTE_RN = 999;
+
+    @MockitoBean
+    private InterbankClient interbankClient;
+
+    @Autowired private TransactionExecutorService transactionExecutorService;
+    @Autowired private AccountRepository          accountRepository;
+    @Autowired private ClientRepository           clientRepository;
+    @Autowired private EmployeeRepository         employeeRepository;
+    @Autowired private CurrencyRepository         currencyRepository;
+    @Autowired private InterbankTransactionRepository txRepo;
+    @Autowired private InterbankMessageRepository    messageRepo;
+    @Autowired private JdbcTemplate jdbcTemplate;
+    @Autowired private DataSource   dataSource;
+
+    @BeforeEach
+    void resetDatabase() {
+        IntegrationTestCleanup.truncateAllTables(dataSource);
+    }
+
+    // =========================================================================
+    // Test 1 — Local-only transfer
+    // =========================================================================
+
+    @Test
+    @DisplayName("Local-only: balanced tx → commit, sender balance debited, receiver credited")
+    void localOnly_balancedTx_balancesTransferCorrectly() {
+        Client owner = seedClient("it-local@test.com");
+        Employee emp = seedEmployee("emp-local@test.com", "emp-local");
+        Currency rsd = seedCurrency("RSD");
+
+        String senderNum   = "222000000000001111";
+        String receiverNum = "222000000000002222";
+        seedAccount(senderNum,   owner, emp, rsd, new BigDecimal("500.00"));
+        seedAccount(receiverNum, owner, emp, rsd, BigDecimal.ZERO);
+
+        // amount > 0 = debit (account receives), amount < 0 = credit (account gives)
+        Transaction tx = transactionExecutorService.formTransaction(List.of(
+                new Posting(new TxAccount.Account(receiverNum), BigDecimal.valueOf(100),
+                        new Asset.Monas(new MonetaryAsset(CurrencyCode.RSD))),
+                new Posting(new TxAccount.Account(senderNum),   BigDecimal.valueOf(-100),
+                        new Asset.Monas(new MonetaryAsset(CurrencyCode.RSD)))
+        ), "IT local transfer", null, "289", "test");
+
+        transactionExecutorService.execute(tx);
+
+        Account sender   = accountRepository.findByAccountNumber(senderNum).orElseThrow();
+        Account receiver = accountRepository.findByAccountNumber(receiverNum).orElseThrow();
+
+        assertThat(sender.getBalance()).isEqualByComparingTo("400.00");
+        assertThat(sender.getAvailableBalance()).isEqualByComparingTo("400.00");
+        assertThat(sender.getReservedAmount()).isEqualByComparingTo("0.00");
+
+        assertThat(receiver.getBalance()).isEqualByComparingTo("100.00");
+        assertThat(receiver.getAvailableBalance()).isEqualByComparingTo("100.00");
+
+        InterbankTransaction ibTx = txRepo.findByTransactionRoutingNumberAndTransactionIdString(
+                tx.transactionId().routingNumber(), tx.transactionId().id()).orElseThrow();
+        assertThat(ibTx.getStatus()).isEqualTo(InterbankTransactionStatus.COMMITTED);
+
+        verifyNoInteractions(interbankClient);
+    }
+
+    // =========================================================================
+    // Test 2 — Cross-bank: remote bank votes YES → commit
+    // =========================================================================
+
+    @Test
+    @DisplayName("Cross-bank: remote YES → COMMIT_TX sent, local balance debited after commit")
+    void crossBank_remoteVotesYes_localBalanceDebited() {
+        Client owner = seedClient("it-yes@test.com");
+        Employee emp = seedEmployee("emp-yes@test.com", "emp-yes");
+        Currency rsd = seedCurrency("RSD");
+
+        String localNum  = "222000000000003333";
+        String remoteNum = "999000000000004444";
+        seedAccount(localNum, owner, emp, rsd, new BigDecimal("500.00"));
+
+        Transaction tx = transactionExecutorService.formTransaction(List.of(
+                new Posting(new TxAccount.Account(remoteNum), BigDecimal.valueOf(100),
+                        new Asset.Monas(new MonetaryAsset(CurrencyCode.RSD))),
+                new Posting(new TxAccount.Account(localNum),  BigDecimal.valueOf(-100),
+                        new Asset.Monas(new MonetaryAsset(CurrencyCode.RSD)))
+        ), "IT cross-bank YES", null, "289", "test");
+
+        when(interbankClient.sendMessage(eq(REMOTE_RN), eq(MessageType.NEW_TX), any(), eq(TransactionVote.class)))
+                .thenReturn(new TransactionVote(TransactionVote.Vote.YES, List.of()));
+        when(interbankClient.sendMessage(eq(REMOTE_RN), eq(MessageType.COMMIT_TX), any(), eq(Void.class)))
+                .thenReturn(null);
+
+        transactionExecutorService.execute(tx);
+
+        Account local = accountRepository.findByAccountNumber(localNum).orElseThrow();
+        assertThat(local.getBalance()).isEqualByComparingTo("400.00");
+        assertThat(local.getAvailableBalance()).isEqualByComparingTo("400.00");
+        assertThat(local.getReservedAmount()).isEqualByComparingTo("0.00");
+
+        InterbankTransaction ibTx = txRepo.findByTransactionRoutingNumberAndTransactionIdString(
+                tx.transactionId().routingNumber(), tx.transactionId().id()).orElseThrow();
+        assertThat(ibTx.getStatus()).isEqualTo(InterbankTransactionStatus.COMMITTED);
+
+        verify(interbankClient).sendMessage(eq(REMOTE_RN), eq(MessageType.NEW_TX), any(), eq(TransactionVote.class));
+        verify(interbankClient).sendMessage(eq(REMOTE_RN), eq(MessageType.COMMIT_TX), any(), eq(Void.class));
+        verify(interbankClient, never()).sendMessage(any(Integer.class), eq(MessageType.ROLLBACK_TX), any(), any());
+
+        List<InterbankMessage> messages = messageRepo.findAll();
+        assertThat(messages).hasSize(2);
+        assertThat(messages).anySatisfy(m -> {
+            assertThat(m.getMessageType()).isEqualTo(MessageType.NEW_TX);
+            assertThat(m.getStatus()).isEqualTo(InterbankMessageStatus.SENT);
+        });
+        assertThat(messages).anySatisfy(m -> {
+            assertThat(m.getMessageType()).isEqualTo(MessageType.COMMIT_TX);
+            assertThat(m.getStatus()).isEqualTo(InterbankMessageStatus.SENT);
+        });
+    }
+
+    // =========================================================================
+    // Test 3 — Cross-bank: remote bank votes NO → rollback
+    // =========================================================================
+
+    @Test
+    @DisplayName("Cross-bank: remote NO → ROLLBACK_TX sent, local balance fully restored")
+    void crossBank_remoteVotesNo_localBalanceRestored() {
+        Client owner = seedClient("it-no@test.com");
+        Employee emp = seedEmployee("emp-no@test.com", "emp-no");
+        Currency rsd = seedCurrency("RSD");
+
+        String localNum  = "222000000000005555";
+        String remoteNum = "999000000000006666";
+        seedAccount(localNum, owner, emp, rsd, new BigDecimal("500.00"));
+
+        Transaction tx = transactionExecutorService.formTransaction(List.of(
+                new Posting(new TxAccount.Account(remoteNum), BigDecimal.valueOf(100),
+                        new Asset.Monas(new MonetaryAsset(CurrencyCode.RSD))),
+                new Posting(new TxAccount.Account(localNum),  BigDecimal.valueOf(-100),
+                        new Asset.Monas(new MonetaryAsset(CurrencyCode.RSD)))
+        ), "IT cross-bank NO", null, "289", "test");
+
+        when(interbankClient.sendMessage(eq(REMOTE_RN), eq(MessageType.NEW_TX), any(), eq(TransactionVote.class)))
+                .thenReturn(new TransactionVote(TransactionVote.Vote.NO, List.of()));
+        when(interbankClient.sendMessage(eq(REMOTE_RN), eq(MessageType.ROLLBACK_TX), any(), eq(Void.class)))
+                .thenReturn(null);
+
+        transactionExecutorService.execute(tx);
+
+        Account local = accountRepository.findByAccountNumber(localNum).orElseThrow();
+        assertThat(local.getBalance()).isEqualByComparingTo("500.00");
+        assertThat(local.getAvailableBalance()).isEqualByComparingTo("500.00");
+        assertThat(local.getReservedAmount()).isEqualByComparingTo("0.00");
+
+        InterbankTransaction ibTx = txRepo.findByTransactionRoutingNumberAndTransactionIdString(
+                tx.transactionId().routingNumber(), tx.transactionId().id()).orElseThrow();
+        assertThat(ibTx.getStatus()).isEqualTo(InterbankTransactionStatus.ROLLED_BACK);
+
+        verify(interbankClient).sendMessage(eq(REMOTE_RN), eq(MessageType.NEW_TX), any(), eq(TransactionVote.class));
+        verify(interbankClient).sendMessage(eq(REMOTE_RN), eq(MessageType.ROLLBACK_TX), any(), eq(Void.class));
+        verify(interbankClient, never()).sendMessage(any(Integer.class), eq(MessageType.COMMIT_TX), any(), any());
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private Client seedClient(String email) {
+        Client c = new Client();
+        c.setFirstName("Test");
+        c.setLastName("IT");
+        c.setDateOfBirth(LocalDate.of(1990, 1, 1));
+        c.setGender("M");
+        c.setEmail(email);
+        c.setPhone("+381600000001");
+        c.setAddress("Test Address");
+        c.setPassword("x");
+        c.setSaltPassword("salt");
+        c.setActive(true);
+        return clientRepository.save(c);
+    }
+
+    private Employee seedEmployee(String email, String username) {
+        return employeeRepository.save(Employee.builder()
+                .firstName("Emp").lastName("IT")
+                .dateOfBirth(LocalDate.of(1990, 1, 1))
+                .gender("M").email(email).phone("+381600000000")
+                .address("Test").username(username)
+                .password("x").saltPassword("salt")
+                .position("QA").department("IT")
+                .active(true).permissions(Set.of())
+                .build());
+    }
+
+    private Currency seedCurrency(String code) {
+        Long id;
+        List<Long> ids = jdbcTemplate.query(
+                "select id from currencies where code = ?",
+                (rs, i) -> rs.getLong(1), code);
+        if (ids.isEmpty()) {
+            jdbcTemplate.update(
+                    "insert into currencies(code, name, symbol, country, description, active) values (?,?,?,?,?,?)",
+                    code, code + " currency", code.charAt(0) + "", "RS", "test", true);
+            id = jdbcTemplate.queryForObject("select id from currencies where code = ?", Long.class, code);
+        } else {
+            id = ids.get(0);
+        }
+        return currencyRepository.findById(id).orElseThrow();
+    }
+
+    private void seedAccount(String number, Client owner, Employee emp,
+                              Currency currency, BigDecimal balance) {
+        accountRepository.save(Account.builder()
+                .accountNumber(number)
+                .accountType(AccountType.CHECKING)
+                .currency(currency)
+                .client(owner)
+                .employee(emp)
+                .status(AccountStatus.ACTIVE)
+                .balance(balance)
+                .availableBalance(balance)
+                .reservedAmount(BigDecimal.ZERO)
+                .dailyLimit(new BigDecimal("999999999.00"))
+                .monthlyLimit(new BigDecimal("999999999.00"))
+                .dailySpending(BigDecimal.ZERO)
+                .monthlySpending(BigDecimal.ZERO)
+                .build());
+    }
+}

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/interbank/service/TransactionExecutorServiceTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/interbank/service/TransactionExecutorServiceTest.java
@@ -21,7 +21,6 @@ import rs.raf.banka2_bek.interbank.model.InterbankTransaction;
 import rs.raf.banka2_bek.interbank.model.InterbankTransactionStatus;
 import rs.raf.banka2_bek.interbank.protocol.*;
 import rs.raf.banka2_bek.interbank.repository.InterbankTransactionRepository;
-import rs.raf.banka2_bek.order.service.CurrencyConversionService;
 import rs.raf.banka2_bek.portfolio.model.Portfolio;
 import rs.raf.banka2_bek.portfolio.repository.PortfolioRepository;
 import rs.raf.banka2_bek.stock.model.Listing;
@@ -54,7 +53,6 @@ class TransactionExecutorServiceTest {
     @Mock private PortfolioRepository portfolioRepository;
     @Mock private InterbankReservationApplier reservationApplier;
     @Mock private ListingRepository listingRepository;
-    @Mock private CurrencyConversionService currencyConversionService;
 
     /** Self-proxy replaced with a mock so @Transactional sub-methods can be stubbed. */
     @Mock private TransactionExecutorService self;
@@ -79,7 +77,7 @@ class TransactionExecutorServiceTest {
         service = new TransactionExecutorService(
                 messageService, client, routing, txRepo, objectMapper,
                 accountRepository, portfolioRepository, reservationApplier,
-                listingRepository, currencyConversionService);
+                listingRepository);
 
         ReflectionTestUtils.setField(service, "self", self);
 
@@ -480,7 +478,7 @@ class TransactionExecutorServiceTest {
     @DisplayName("prepareLocal: STOCK credit — portfolio not found → NO + NO_SUCH_ASSET")
     void prepareLocal_portfolioMissing_noVote() {
         when(listingRepository.findByTicker("AAPL")).thenReturn(Optional.of(buildListing(1L, "AAPL")));
-        when(portfolioRepository.findByUserIdAndUserRoleAndListingIdForUpdate(anyLong(), any(), anyLong()))
+        when(portfolioRepository.findByUserIdAndUserRoleAndListingId(anyLong(), any(), anyLong()))
                 .thenReturn(Optional.empty());
 
         TransactionVote vote = service.prepareLocal(localStockTx());
@@ -494,7 +492,7 @@ class TransactionExecutorServiceTest {
     @DisplayName("prepareLocal: STOCK credit — insufficient quantity → NO + INSUFFICIENT_ASSET")
     void prepareLocal_insufficientStock_noVote() {
         when(listingRepository.findByTicker("AAPL")).thenReturn(Optional.of(buildListing(1L, "AAPL")));
-        when(portfolioRepository.findByUserIdAndUserRoleAndListingIdForUpdate(anyLong(), any(), anyLong()))
+        when(portfolioRepository.findByUserIdAndUserRoleAndListingId(anyLong(), any(), anyLong()))
                 .thenReturn(Optional.of(buildPortfolio(3))); // needs 10, has 3
 
         TransactionVote vote = service.prepareLocal(localStockTx());
@@ -508,7 +506,7 @@ class TransactionExecutorServiceTest {
     @DisplayName("prepareLocal: STOCK YES → reserveStock called with correct userId and listingId")
     void prepareLocal_stockYes_reservesStock() {
         when(listingRepository.findByTicker("AAPL")).thenReturn(Optional.of(buildListing(7L, "AAPL")));
-        when(portfolioRepository.findByUserIdAndUserRoleAndListingIdForUpdate(anyLong(), any(), anyLong()))
+        when(portfolioRepository.findByUserIdAndUserRoleAndListingId(anyLong(), any(), anyLong()))
                 .thenReturn(Optional.of(buildPortfolio(20))); // has 20, needs 10
 
         TransactionVote vote = service.prepareLocal(localStockTx());
@@ -552,12 +550,6 @@ class TransactionExecutorServiceTest {
         InterbankTransaction ibt = savedIbt(tx, InterbankTransactionStatus.PREPARING);
         when(txRepo.findByTransactionRoutingNumberAndTransactionIdString(anyInt(), any()))
                 .thenReturn(Optional.of(ibt));
-        when(accountRepository.findForUpdateByAccountNumber(ACCT_A))
-                .thenReturn(Optional.of(buildAccount(ACCT_A, "RSD", BigDecimal.ZERO, AccountStatus.ACTIVE)));
-        when(accountRepository.findForUpdateByAccountNumber(ACCT_B))
-                .thenReturn(Optional.of(buildAccount(ACCT_B, "RSD", BigDecimal.valueOf(500), AccountStatus.ACTIVE)));
-        when(currencyConversionService.convert(any(), eq("RSD"), eq("RSD")))
-                .thenReturn(BigDecimal.valueOf(100));
         stubTxSave();
 
         service.commitLocal(tx.transactionId());
@@ -567,36 +559,12 @@ class TransactionExecutorServiceTest {
     }
 
     @Test
-    @DisplayName("commitLocal: currency conversion applied when posting currency differs from account currency")
-    void commitLocal_currencyConversionApplied() throws Exception {
-        Transaction tx = localMonasTxEur();
-        InterbankTransaction ibt = savedIbt(tx, InterbankTransactionStatus.PREPARING);
-        when(txRepo.findByTransactionRoutingNumberAndTransactionIdString(anyInt(), any()))
-                .thenReturn(Optional.of(ibt));
-        when(accountRepository.findForUpdateByAccountNumber(ACCT_A))
-                .thenReturn(Optional.of(buildAccount(ACCT_A, "RSD", BigDecimal.ZERO, AccountStatus.ACTIVE)));
-        when(accountRepository.findForUpdateByAccountNumber(ACCT_B))
-                .thenReturn(Optional.of(buildAccount(ACCT_B, "RSD", BigDecimal.valueOf(50000), AccountStatus.ACTIVE)));
-        when(currencyConversionService.convert(eq(BigDecimal.valueOf(100)), eq("EUR"), eq("RSD")))
-                .thenReturn(BigDecimal.valueOf(11700));
-        stubTxSave();
-
-        service.commitLocal(tx.transactionId());
-
-        verify(currencyConversionService, times(2)).convert(eq(BigDecimal.valueOf(100)), eq("EUR"), eq("RSD"));
-        verify(reservationApplier).commitMonas(eq(ACCT_B), eq(BigDecimal.valueOf(11700)), eq(false));
-    }
-
-    @Test
     @DisplayName("commitLocal: status set to COMMITTED with timestamp")
     void commitLocal_statusSetToCommitted() throws Exception {
         Transaction tx = localMonasTx();
         InterbankTransaction ibt = savedIbt(tx, InterbankTransactionStatus.PREPARING);
         when(txRepo.findByTransactionRoutingNumberAndTransactionIdString(anyInt(), any()))
                 .thenReturn(Optional.of(ibt));
-        when(accountRepository.findForUpdateByAccountNumber(any()))
-                .thenReturn(Optional.of(buildAccount(ACCT_A, "RSD", BigDecimal.ZERO, AccountStatus.ACTIVE)));
-        when(currencyConversionService.convert(any(), any(), any())).thenReturn(BigDecimal.valueOf(100));
         stubTxSave();
 
         service.commitLocal(tx.transactionId());
@@ -645,8 +613,8 @@ class TransactionExecutorServiceTest {
 
         service.commitLocal(tx.transactionId());
 
-        verify(reservationApplier).commitStock(eq(99L), eq("CLIENT"), eq(7L), eq(10), eq(true));
-        verify(reservationApplier).commitStock(eq(42L), eq("CLIENT"), eq(7L), eq(10), eq(false));
+        verify(reservationApplier).commitStock(eq(99L), eq("CLIENT"), any(Listing.class), eq(10), eq(true));
+        verify(reservationApplier).commitStock(eq(42L), eq("CLIENT"), any(Listing.class), eq(10), eq(false));
     }
 
     @Test
@@ -673,34 +641,12 @@ class TransactionExecutorServiceTest {
         InterbankTransaction ibt = savedIbt(tx, InterbankTransactionStatus.PREPARING);
         when(txRepo.findByTransactionRoutingNumberAndTransactionIdString(anyInt(), any()))
                 .thenReturn(Optional.of(ibt));
-        when(accountRepository.findForUpdateByAccountNumber(ACCT_B))
-                .thenReturn(Optional.of(buildAccount(ACCT_B, "RSD", BigDecimal.valueOf(500), AccountStatus.ACTIVE)));
-        when(currencyConversionService.convert(any(), any(), any())).thenReturn(BigDecimal.valueOf(100));
         stubTxSave();
 
         service.rollbackLocal(tx.transactionId());
 
         verify(reservationApplier).releaseMonas(eq(ACCT_B), eq(BigDecimal.valueOf(100)));
         verify(reservationApplier, never()).releaseMonas(eq(ACCT_A), any());
-        verify(accountRepository, never()).findForUpdateByAccountNumber(ACCT_A);
-    }
-
-    @Test
-    @DisplayName("rollbackLocal: releaseMonas called with currency-converted amount")
-    void rollbackLocal_releaseMonasWithConvertedAmount() throws Exception {
-        Transaction tx = localMonasTxEur();
-        InterbankTransaction ibt = savedIbt(tx, InterbankTransactionStatus.PREPARING);
-        when(txRepo.findByTransactionRoutingNumberAndTransactionIdString(anyInt(), any()))
-                .thenReturn(Optional.of(ibt));
-        when(accountRepository.findForUpdateByAccountNumber(ACCT_B))
-                .thenReturn(Optional.of(buildAccount(ACCT_B, "RSD", BigDecimal.valueOf(50000), AccountStatus.ACTIVE)));
-        when(currencyConversionService.convert(eq(BigDecimal.valueOf(100)), eq("EUR"), eq("RSD")))
-                .thenReturn(BigDecimal.valueOf(11700));
-        stubTxSave();
-
-        service.rollbackLocal(tx.transactionId());
-
-        verify(reservationApplier).releaseMonas(eq(ACCT_B), eq(BigDecimal.valueOf(11700)));
     }
 
     @Test
@@ -710,9 +656,6 @@ class TransactionExecutorServiceTest {
         InterbankTransaction ibt = savedIbt(tx, InterbankTransactionStatus.PREPARING);
         when(txRepo.findByTransactionRoutingNumberAndTransactionIdString(anyInt(), any()))
                 .thenReturn(Optional.of(ibt));
-        when(accountRepository.findForUpdateByAccountNumber(ACCT_B))
-                .thenReturn(Optional.of(buildAccount(ACCT_B, "RSD", BigDecimal.valueOf(500), AccountStatus.ACTIVE)));
-        when(currencyConversionService.convert(any(), any(), any())).thenReturn(BigDecimal.valueOf(100));
         stubTxSave();
 
         service.rollbackLocal(tx.transactionId());
@@ -887,11 +830,6 @@ class TransactionExecutorServiceTest {
         InterbankTransaction ibt = savedIbt(tx, InterbankTransactionStatus.PREPARING);
         when(txRepo.findByTransactionRoutingNumberAndTransactionIdString(anyInt(), any()))
                 .thenReturn(Optional.of(ibt));
-        when(accountRepository.findForUpdateByAccountNumber(ACCT_A))
-                .thenReturn(Optional.of(buildAccount(ACCT_A, "RSD", BigDecimal.ZERO, AccountStatus.ACTIVE)));
-        when(accountRepository.findForUpdateByAccountNumber(ACCT_B))
-                .thenReturn(Optional.of(buildAccount(ACCT_B, "RSD", BigDecimal.valueOf(500), AccountStatus.ACTIVE)));
-        when(currencyConversionService.convert(any(), any(), any())).thenReturn(BigDecimal.valueOf(100));
         stubTxSave();
 
         service.handleCommitTx(new CommitTransaction(tx.transactionId()), key);
@@ -926,9 +864,6 @@ class TransactionExecutorServiceTest {
         InterbankTransaction ibt = savedIbt(tx, InterbankTransactionStatus.PREPARING);
         when(txRepo.findByTransactionRoutingNumberAndTransactionIdString(anyInt(), any()))
                 .thenReturn(Optional.of(ibt));
-        when(accountRepository.findForUpdateByAccountNumber(ACCT_B))
-                .thenReturn(Optional.of(buildAccount(ACCT_B, "RSD", BigDecimal.valueOf(500), AccountStatus.ACTIVE)));
-        when(currencyConversionService.convert(any(), any(), any())).thenReturn(BigDecimal.valueOf(100));
         stubTxSave();
 
         service.handleRollbackTx(new RollbackTransaction(tx.transactionId()), key);

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/interbank/service/TransactionExecutorServiceTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/interbank/service/TransactionExecutorServiceTest.java
@@ -17,9 +17,14 @@ import rs.raf.banka2_bek.account.model.AccountStatus;
 import rs.raf.banka2_bek.account.repository.AccountRepository;
 import rs.raf.banka2_bek.currency.model.Currency;
 import rs.raf.banka2_bek.interbank.exception.InterbankExceptions;
+import rs.raf.banka2_bek.interbank.model.InterbankOtcContract;
+import rs.raf.banka2_bek.interbank.model.InterbankOtcContractStatus;
+import rs.raf.banka2_bek.interbank.model.InterbankOtcNegotiation;
 import rs.raf.banka2_bek.interbank.model.InterbankTransaction;
 import rs.raf.banka2_bek.interbank.model.InterbankTransactionStatus;
 import rs.raf.banka2_bek.interbank.protocol.*;
+import rs.raf.banka2_bek.interbank.repository.InterbankOtcContractRepository;
+import rs.raf.banka2_bek.interbank.repository.InterbankOtcNegotiationRepository;
 import rs.raf.banka2_bek.interbank.repository.InterbankTransactionRepository;
 import rs.raf.banka2_bek.portfolio.model.Portfolio;
 import rs.raf.banka2_bek.portfolio.repository.PortfolioRepository;
@@ -27,6 +32,8 @@ import rs.raf.banka2_bek.stock.model.Listing;
 import rs.raf.banka2_bek.stock.repository.ListingRepository;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -53,6 +60,8 @@ class TransactionExecutorServiceTest {
     @Mock private PortfolioRepository portfolioRepository;
     @Mock private InterbankReservationApplier reservationApplier;
     @Mock private ListingRepository listingRepository;
+    @Mock private InterbankOtcNegotiationRepository otcNegotiationRepository;
+    @Mock private InterbankOtcContractRepository otcContractRepository;
 
     /** Self-proxy replaced with a mock so @Transactional sub-methods can be stubbed. */
     @Mock private TransactionExecutorService self;
@@ -77,7 +86,7 @@ class TransactionExecutorServiceTest {
         service = new TransactionExecutorService(
                 messageService, client, routing, txRepo, objectMapper,
                 accountRepository, portfolioRepository, reservationApplier,
-                listingRepository);
+                listingRepository, otcNegotiationRepository, otcContractRepository);
 
         ReflectionTestUtils.setField(service, "self", self);
 
@@ -885,6 +894,265 @@ class TransactionExecutorServiceTest {
     }
 
     // =========================================================================
+    // prepareLocal — option pseudo-account (§2.8.6 rules 5 and 6)
+    // =========================================================================
+
+    @Test
+    @DisplayName("prepareLocal: option negotiation not found → NO + OPTION_NEGOTIATION_NOT_FOUND")
+    void prepareLocal_option_negotiationNotFound_noVote() {
+        when(otcNegotiationRepository.findByForeignNegotiationRoutingNumberAndForeignNegotiationIdString(
+                anyInt(), any())).thenReturn(Optional.empty());
+
+        TransactionVote vote = service.prepareLocal(optionOnlyTx("neg-1", "AAPL", 10, "USD", BigDecimal.valueOf(150)));
+
+        assertThat(vote.vote()).isEqualTo(TransactionVote.Vote.NO);
+        assertThat(vote.reasons()).allSatisfy(r ->
+                assertThat(r.reason()).isEqualTo(NoVoteReason.Reason.OPTION_NEGOTIATION_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("prepareLocal: negotiation found but contract not found → NO + OPTION_NEGOTIATION_NOT_FOUND")
+    void prepareLocal_option_contractNotFound_noVote() {
+        InterbankOtcNegotiation neg = new InterbankOtcNegotiation();
+        neg.setId(10L);
+        when(otcNegotiationRepository.findByForeignNegotiationRoutingNumberAndForeignNegotiationIdString(
+                anyInt(), any())).thenReturn(Optional.of(neg));
+        when(otcContractRepository.findBySourceNegotiationId(10L)).thenReturn(Optional.empty());
+
+        TransactionVote vote = service.prepareLocal(optionOnlyTx("neg-1", "AAPL", 10, "USD", BigDecimal.valueOf(150)));
+
+        assertThat(vote.vote()).isEqualTo(TransactionVote.Vote.NO);
+        assertThat(vote.reasons()).allSatisfy(r ->
+                assertThat(r.reason()).isEqualTo(NoVoteReason.Reason.OPTION_NEGOTIATION_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("prepareLocal: contract status EXERCISED → NO + OPTION_USED_OR_EXPIRED")
+    void prepareLocal_option_contractExercised_noVote() {
+        stubOptionNegAndContract(buildContract(InterbankOtcContractStatus.EXERCISED,
+                LocalDate.now().plusDays(30), "AAPL", BigDecimal.valueOf(10), BigDecimal.valueOf(150), "USD"));
+
+        TransactionVote vote = service.prepareLocal(optionOnlyTx("neg-1", "AAPL", 10, "USD", BigDecimal.valueOf(150)));
+
+        assertThat(vote.vote()).isEqualTo(TransactionVote.Vote.NO);
+        assertThat(vote.reasons()).allSatisfy(r ->
+                assertThat(r.reason()).isEqualTo(NoVoteReason.Reason.OPTION_USED_OR_EXPIRED));
+    }
+
+    @Test
+    @DisplayName("prepareLocal: contract status EXPIRED → NO + OPTION_USED_OR_EXPIRED")
+    void prepareLocal_option_contractExpired_noVote() {
+        stubOptionNegAndContract(buildContract(InterbankOtcContractStatus.EXPIRED,
+                LocalDate.now().plusDays(30), "AAPL", BigDecimal.valueOf(10), BigDecimal.valueOf(150), "USD"));
+
+        TransactionVote vote = service.prepareLocal(optionOnlyTx("neg-1", "AAPL", 10, "USD", BigDecimal.valueOf(150)));
+
+        assertThat(vote.vote()).isEqualTo(TransactionVote.Vote.NO);
+        assertThat(vote.reasons()).allSatisfy(r ->
+                assertThat(r.reason()).isEqualTo(NoVoteReason.Reason.OPTION_USED_OR_EXPIRED));
+    }
+
+    @Test
+    @DisplayName("prepareLocal: contract ACTIVE but settlementDate in the past → NO + OPTION_USED_OR_EXPIRED")
+    void prepareLocal_option_settlementDatePast_noVote() {
+        stubOptionNegAndContract(buildContract(InterbankOtcContractStatus.ACTIVE,
+                LocalDate.now().minusDays(1), "AAPL", BigDecimal.valueOf(10), BigDecimal.valueOf(150), "USD"));
+
+        TransactionVote vote = service.prepareLocal(optionOnlyTx("neg-1", "AAPL", 10, "USD", BigDecimal.valueOf(150)));
+
+        assertThat(vote.vote()).isEqualTo(TransactionVote.Vote.NO);
+        assertThat(vote.reasons()).allSatisfy(r ->
+                assertThat(r.reason()).isEqualTo(NoVoteReason.Reason.OPTION_USED_OR_EXPIRED));
+    }
+
+    @Test
+    @DisplayName("prepareLocal: contract valid but no stock companion posting → NO + OPTION_AMOUNT_INCORRECT")
+    void prepareLocal_option_missingStockPosting_noVote() {
+        stubOptionNegAndContract(buildContract(InterbankOtcContractStatus.ACTIVE,
+                LocalDate.now().plusDays(30), "AAPL", BigDecimal.valueOf(10), BigDecimal.valueOf(150), "USD"));
+
+        // tx has balanced option postings + monas companion but NO stock
+        ForeignBankId negId = new ForeignBankId(MY_RN, "neg-1");
+        OptionDescription opt = buildOptionDescription(negId, "AAPL", BigDecimal.valueOf(10), "USD", BigDecimal.valueOf(150));
+        Transaction tx = new Transaction(List.of(
+                new Posting(new TxAccount.Option(negId), BigDecimal.valueOf(10), new Asset.OptionAsset(opt)),
+                new Posting(new TxAccount.Option(negId), BigDecimal.valueOf(-10), new Asset.OptionAsset(opt)),
+                new Posting(new TxAccount.Account(REMOTE_RN + "000001"), BigDecimal.valueOf(-1500), new Asset.Monas(new MonetaryAsset(CurrencyCode.USD))),
+                new Posting(new TxAccount.Account(REMOTE_RN + "000002"), BigDecimal.valueOf(1500), new Asset.Monas(new MonetaryAsset(CurrencyCode.USD)))
+        ), new ForeignBankId(MY_RN, "tx-no-stock"), null, null, null, null);
+
+        TransactionVote vote = service.prepareLocal(tx);
+
+        assertThat(vote.vote()).isEqualTo(TransactionVote.Vote.NO);
+        assertThat(vote.reasons()).allSatisfy(r ->
+                assertThat(r.reason()).isEqualTo(NoVoteReason.Reason.OPTION_AMOUNT_INCORRECT));
+    }
+
+    @Test
+    @DisplayName("prepareLocal: contract valid but no monas companion posting → NO + OPTION_AMOUNT_INCORRECT")
+    void prepareLocal_option_missingMoneyPosting_noVote() {
+        stubOptionNegAndContract(buildContract(InterbankOtcContractStatus.ACTIVE,
+                LocalDate.now().plusDays(30), "AAPL", BigDecimal.valueOf(10), BigDecimal.valueOf(150), "USD"));
+
+        ForeignBankId negId = new ForeignBankId(MY_RN, "neg-1");
+        OptionDescription opt = buildOptionDescription(negId, "AAPL", BigDecimal.valueOf(10), "USD", BigDecimal.valueOf(150));
+        Transaction tx = new Transaction(List.of(
+                new Posting(new TxAccount.Option(negId), BigDecimal.valueOf(10), new Asset.OptionAsset(opt)),
+                new Posting(new TxAccount.Option(negId), BigDecimal.valueOf(-10), new Asset.OptionAsset(opt)),
+                new Posting(new TxAccount.Person(new ForeignBankId(REMOTE_RN, "seller")), BigDecimal.valueOf(-10), new Asset.Stock(new StockDescription("AAPL"))),
+                new Posting(new TxAccount.Person(new ForeignBankId(REMOTE_RN, "buyer")), BigDecimal.valueOf(10), new Asset.Stock(new StockDescription("AAPL")))
+        ), new ForeignBankId(MY_RN, "tx-no-monas"), null, null, null, null);
+
+        TransactionVote vote = service.prepareLocal(tx);
+
+        assertThat(vote.vote()).isEqualTo(TransactionVote.Vote.NO);
+        assertThat(vote.reasons()).allSatisfy(r ->
+                assertThat(r.reason()).isEqualTo(NoVoteReason.Reason.OPTION_AMOUNT_INCORRECT));
+    }
+
+    @Test
+    @DisplayName("prepareLocal: wrong stock amount → NO + OPTION_AMOUNT_INCORRECT")
+    void prepareLocal_option_wrongStockAmount_noVote() {
+        stubOptionNegAndContract(buildContract(InterbankOtcContractStatus.ACTIVE,
+                LocalDate.now().plusDays(30), "AAPL", BigDecimal.valueOf(10), BigDecimal.valueOf(150), "USD"));
+
+        ForeignBankId negId = new ForeignBankId(MY_RN, "neg-1");
+        OptionDescription opt = buildOptionDescription(negId, "AAPL", BigDecimal.valueOf(10), "USD", BigDecimal.valueOf(150));
+        Transaction tx = new Transaction(List.of(
+                new Posting(new TxAccount.Option(negId), BigDecimal.valueOf(10), new Asset.OptionAsset(opt)),
+                new Posting(new TxAccount.Option(negId), BigDecimal.valueOf(-10), new Asset.OptionAsset(opt)),
+                // wrong stock amount: 5 instead of 10
+                new Posting(new TxAccount.Person(new ForeignBankId(REMOTE_RN, "seller")), BigDecimal.valueOf(-5), new Asset.Stock(new StockDescription("AAPL"))),
+                new Posting(new TxAccount.Person(new ForeignBankId(REMOTE_RN, "buyer")), BigDecimal.valueOf(5), new Asset.Stock(new StockDescription("AAPL"))),
+                new Posting(new TxAccount.Account(REMOTE_RN + "000001"), BigDecimal.valueOf(-1500), new Asset.Monas(new MonetaryAsset(CurrencyCode.USD))),
+                new Posting(new TxAccount.Account(REMOTE_RN + "000002"), BigDecimal.valueOf(1500), new Asset.Monas(new MonetaryAsset(CurrencyCode.USD)))
+        ), new ForeignBankId(MY_RN, "tx-wrong-stock-amt"), null, null, null, null);
+
+        TransactionVote vote = service.prepareLocal(tx);
+
+        assertThat(vote.vote()).isEqualTo(TransactionVote.Vote.NO);
+        assertThat(vote.reasons()).allSatisfy(r ->
+                assertThat(r.reason()).isEqualTo(NoVoteReason.Reason.OPTION_AMOUNT_INCORRECT));
+    }
+
+    @Test
+    @DisplayName("prepareLocal: wrong money amount → NO + OPTION_AMOUNT_INCORRECT")
+    void prepareLocal_option_wrongMoneyAmount_noVote() {
+        stubOptionNegAndContract(buildContract(InterbankOtcContractStatus.ACTIVE,
+                LocalDate.now().plusDays(30), "AAPL", BigDecimal.valueOf(10), BigDecimal.valueOf(150), "USD"));
+
+        ForeignBankId negId = new ForeignBankId(MY_RN, "neg-1");
+        OptionDescription opt = buildOptionDescription(negId, "AAPL", BigDecimal.valueOf(10), "USD", BigDecimal.valueOf(150));
+        Transaction tx = new Transaction(List.of(
+                new Posting(new TxAccount.Option(negId), BigDecimal.valueOf(10), new Asset.OptionAsset(opt)),
+                new Posting(new TxAccount.Option(negId), BigDecimal.valueOf(-10), new Asset.OptionAsset(opt)),
+                new Posting(new TxAccount.Person(new ForeignBankId(REMOTE_RN, "seller")), BigDecimal.valueOf(-10), new Asset.Stock(new StockDescription("AAPL"))),
+                new Posting(new TxAccount.Person(new ForeignBankId(REMOTE_RN, "buyer")), BigDecimal.valueOf(10), new Asset.Stock(new StockDescription("AAPL"))),
+                // wrong money amount: 999 instead of 1500 (10 × 150)
+                new Posting(new TxAccount.Account(REMOTE_RN + "000001"), BigDecimal.valueOf(-999), new Asset.Monas(new MonetaryAsset(CurrencyCode.USD))),
+                new Posting(new TxAccount.Account(REMOTE_RN + "000002"), BigDecimal.valueOf(999), new Asset.Monas(new MonetaryAsset(CurrencyCode.USD)))
+        ), new ForeignBankId(MY_RN, "tx-wrong-money-amt"), null, null, null, null);
+
+        TransactionVote vote = service.prepareLocal(tx);
+
+        assertThat(vote.vote()).isEqualTo(TransactionVote.Vote.NO);
+        assertThat(vote.reasons()).allSatisfy(r ->
+                assertThat(r.reason()).isEqualTo(NoVoteReason.Reason.OPTION_AMOUNT_INCORRECT));
+    }
+
+    @Test
+    @DisplayName("prepareLocal: valid option with correct companions → YES, no reserve calls for option")
+    void prepareLocal_option_allCorrect_yesVote() {
+        stubOptionNegAndContract(buildContract(InterbankOtcContractStatus.ACTIVE,
+                LocalDate.now().plusDays(30), "AAPL", BigDecimal.valueOf(10), BigDecimal.valueOf(150), "USD"));
+
+        TransactionVote vote = service.prepareLocal(fullOptionTx("neg-1", "AAPL", 10, "USD", BigDecimal.valueOf(150)));
+
+        assertThat(vote.vote()).isEqualTo(TransactionVote.Vote.YES);
+        verifyNoInteractions(reservationApplier);
+    }
+
+    // =========================================================================
+    // commitLocal — option (§2.8.6 commit marks contract EXERCISED)
+    // =========================================================================
+
+    @Test
+    @DisplayName("commitLocal: option posting → contract marked EXERCISED with exercisedAt timestamp")
+    void commitLocal_optionPosting_contractMarkedExercised() throws Exception {
+        ForeignBankId negId = new ForeignBankId(MY_RN, "neg-commit");
+        OptionDescription opt = buildOptionDescription(negId, "AAPL", BigDecimal.valueOf(10), "USD", BigDecimal.valueOf(150));
+        Transaction tx = new Transaction(List.of(
+                new Posting(new TxAccount.Option(negId), BigDecimal.valueOf(10), new Asset.OptionAsset(opt)),
+                new Posting(new TxAccount.Option(negId), BigDecimal.valueOf(-10), new Asset.OptionAsset(opt))
+        ), new ForeignBankId(MY_RN, "tx-opt-commit"), null, null, null, null);
+
+        InterbankTransaction ibt = savedIbt(tx, InterbankTransactionStatus.PREPARING);
+        when(txRepo.findByTransactionRoutingNumberAndTransactionIdString(anyInt(), any()))
+                .thenReturn(Optional.of(ibt));
+        stubTxSave();
+
+        InterbankOtcNegotiation neg = new InterbankOtcNegotiation();
+        neg.setId(55L);
+        when(otcNegotiationRepository.findByForeignNegotiationRoutingNumberAndForeignNegotiationIdString(
+                eq(MY_RN), eq("neg-commit"))).thenReturn(Optional.of(neg));
+
+        InterbankOtcContract contract = new InterbankOtcContract();
+        contract.setStatus(InterbankOtcContractStatus.ACTIVE);
+        when(otcContractRepository.findBySourceNegotiationId(55L)).thenReturn(Optional.of(contract));
+        when(otcContractRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        service.commitLocal(tx.transactionId());
+
+        assertThat(contract.getStatus()).isEqualTo(InterbankOtcContractStatus.EXERCISED);
+        assertThat(contract.getExercisedAt()).isNotNull();
+        verify(otcContractRepository, atLeastOnce()).save(contract);
+    }
+
+    @Test
+    @DisplayName("commitLocal: already COMMITTED → no contract lookup (idempotent)")
+    void commitLocal_optionPosting_alreadyCommitted_noContractLookup() throws Exception {
+        ForeignBankId negId = new ForeignBankId(MY_RN, "neg-idem");
+        OptionDescription opt = buildOptionDescription(negId, "AAPL", BigDecimal.valueOf(10), "USD", BigDecimal.valueOf(150));
+        Transaction tx = new Transaction(List.of(
+                new Posting(new TxAccount.Option(negId), BigDecimal.valueOf(10), new Asset.OptionAsset(opt)),
+                new Posting(new TxAccount.Option(negId), BigDecimal.valueOf(-10), new Asset.OptionAsset(opt))
+        ), new ForeignBankId(MY_RN, "tx-opt-idem"), null, null, null, null);
+
+        InterbankTransaction ibt = savedIbt(tx, InterbankTransactionStatus.COMMITTED);
+        when(txRepo.findByTransactionRoutingNumberAndTransactionIdString(anyInt(), any()))
+                .thenReturn(Optional.of(ibt));
+
+        service.commitLocal(tx.transactionId());
+
+        verifyNoInteractions(otcNegotiationRepository, otcContractRepository);
+    }
+
+    // =========================================================================
+    // rollbackLocal — option (no-op)
+    // =========================================================================
+
+    @Test
+    @DisplayName("rollbackLocal: option posting is a no-op — no contract lookup, no release calls")
+    void rollbackLocal_optionPosting_noOpOnContract() throws Exception {
+        ForeignBankId negId = new ForeignBankId(MY_RN, "neg-rb");
+        OptionDescription opt = buildOptionDescription(negId, "AAPL", BigDecimal.valueOf(10), "USD", BigDecimal.valueOf(150));
+        Transaction tx = new Transaction(List.of(
+                new Posting(new TxAccount.Option(negId), BigDecimal.valueOf(-10), new Asset.OptionAsset(opt)),
+                new Posting(new TxAccount.Option(negId), BigDecimal.valueOf(10), new Asset.OptionAsset(opt))
+        ), new ForeignBankId(MY_RN, "tx-opt-rb"), null, null, null, null);
+
+        InterbankTransaction ibt = savedIbt(tx, InterbankTransactionStatus.PREPARING);
+        when(txRepo.findByTransactionRoutingNumberAndTransactionIdString(anyInt(), any()))
+                .thenReturn(Optional.of(ibt));
+        stubTxSave();
+
+        service.rollbackLocal(tx.transactionId());
+
+        verifyNoInteractions(otcNegotiationRepository, otcContractRepository, reservationApplier);
+        assertThat(ibt.getStatus()).isEqualTo(InterbankTransactionStatus.ROLLED_BACK);
+    }
+
+    // =========================================================================
     // Helpers — transactions
     // =========================================================================
 
@@ -1012,5 +1280,69 @@ class TransactionExecutorServiceTest {
     private TransactionVote noVote() {
         return new TransactionVote(TransactionVote.Vote.NO,
                 List.of(new NoVoteReason(NoVoteReason.Reason.INSUFFICIENT_ASSET, null)));
+    }
+
+    // =========================================================================
+    // Helpers — option builders
+    // =========================================================================
+
+    private OptionDescription buildOptionDescription(ForeignBankId negId, String ticker,
+            BigDecimal quantity, String currencyCode, BigDecimal strikePrice) {
+        CurrencyCode ccy = CurrencyCode.valueOf(currencyCode);
+        return new OptionDescription(negId, new StockDescription(ticker),
+                new MonetaryValue(ccy, strikePrice),
+                OffsetDateTime.now().plusDays(30), quantity);
+    }
+
+    /** Balanced tx with only option postings (no companion stock/monas). */
+    private Transaction optionOnlyTx(String negIdStr, String ticker, int quantity,
+            String currencyCode, BigDecimal strikePrice) {
+        ForeignBankId negId = new ForeignBankId(MY_RN, negIdStr);
+        OptionDescription opt = buildOptionDescription(negId, ticker, BigDecimal.valueOf(quantity), currencyCode, strikePrice);
+        return new Transaction(List.of(
+                new Posting(new TxAccount.Option(negId), BigDecimal.valueOf(quantity), new Asset.OptionAsset(opt)),
+                new Posting(new TxAccount.Option(negId), BigDecimal.valueOf(-quantity), new Asset.OptionAsset(opt))
+        ), new ForeignBankId(MY_RN, "tx-opt-only"), null, null, null, null);
+    }
+
+    /**
+     * Full option exercise tx: balanced option postings + remote companion stock and monas.
+     * amount × strikePrice = required money. All companion postings are remote so they pass
+     * the local posting validation loop but are visible to the anyMatch companion check.
+     */
+    private Transaction fullOptionTx(String negIdStr, String ticker, int quantity,
+            String currencyCode, BigDecimal strikePrice) {
+        ForeignBankId negId = new ForeignBankId(MY_RN, negIdStr);
+        OptionDescription opt = buildOptionDescription(negId, ticker, BigDecimal.valueOf(quantity), currencyCode, strikePrice);
+        BigDecimal money = strikePrice.multiply(BigDecimal.valueOf(quantity));
+        CurrencyCode ccy = CurrencyCode.valueOf(currencyCode);
+        return new Transaction(List.of(
+                new Posting(new TxAccount.Option(negId), BigDecimal.valueOf(quantity), new Asset.OptionAsset(opt)),
+                new Posting(new TxAccount.Option(negId), BigDecimal.valueOf(-quantity), new Asset.OptionAsset(opt)),
+                new Posting(new TxAccount.Person(new ForeignBankId(REMOTE_RN, "seller")), BigDecimal.valueOf(-quantity), new Asset.Stock(new StockDescription(ticker))),
+                new Posting(new TxAccount.Person(new ForeignBankId(REMOTE_RN, "buyer")), BigDecimal.valueOf(quantity), new Asset.Stock(new StockDescription(ticker))),
+                new Posting(new TxAccount.Account(REMOTE_RN + "000001"), money.negate(), new Asset.Monas(new MonetaryAsset(ccy))),
+                new Posting(new TxAccount.Account(REMOTE_RN + "000002"), money, new Asset.Monas(new MonetaryAsset(ccy)))
+        ), new ForeignBankId(MY_RN, "tx-opt-full"), null, null, null, null);
+    }
+
+    private InterbankOtcContract buildContract(InterbankOtcContractStatus status, LocalDate settlementDate,
+            String ticker, BigDecimal quantity, BigDecimal strikePrice, String strikeCurrency) {
+        InterbankOtcContract c = new InterbankOtcContract();
+        c.setStatus(status);
+        c.setSettlementDate(settlementDate);
+        c.setTicker(ticker);
+        c.setQuantity(quantity);
+        c.setStrikePrice(strikePrice);
+        c.setStrikeCurrency(strikeCurrency);
+        return c;
+    }
+
+    private void stubOptionNegAndContract(InterbankOtcContract contract) {
+        InterbankOtcNegotiation neg = new InterbankOtcNegotiation();
+        neg.setId(10L);
+        when(otcNegotiationRepository.findByForeignNegotiationRoutingNumberAndForeignNegotiationIdString(
+                anyInt(), any())).thenReturn(Optional.of(neg));
+        when(otcContractRepository.findBySourceNegotiationId(10L)).thenReturn(Optional.of(contract));
     }
 }


### PR DESCRIPTION
co-author: @sundjerbob 

- dodat integracioni test InterbankTwoPhaseCommitIT sa tri scenarija: _local-only transfer_ (bez InterbankClient poziva) i _remote transfer_, YES (salje se COMMIT_TX) ili NO (vraca NO, salje ROLLBACK_TX) scenario
- dodato verifikaciono pravilo za pseudo-account za opcije, ima posebnu validaciju (**protokol 2.8.6, pravila 5 i 6** https://arsen.srht.site/si-tx-proto/notes.html#orgfbd1be5)