### PR TITLE
feat: stedna knjizica (oroceni depozit) + 17 bagova manuelnog testiranja 12.05.2026

### DIFF
--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/auth/config/GlobalExceptionHandler.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/auth/config/GlobalExceptionHandler.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import rs.raf.banka2_bek.auth.dto.MessageResponseDto;
+import rs.raf.banka2_bek.auth.exception.AuthenticationFailedException;
+import rs.raf.banka2_bek.auth.service.AccountLockoutService;
 import org.springframework.security.access.AccessDeniedException;
 
 @RestControllerAdvice
@@ -44,6 +46,31 @@ public class GlobalExceptionHandler {
     public ResponseEntity<MessageResponseDto> handleForbidden(IllegalStateException ex) {
         return ResponseEntity
                 .status(HttpStatus.FORBIDDEN)
+                .body(new MessageResponseDto(ex.getMessage()));
+    }
+
+    /**
+     * Spec Celina 1 Sc 2/3/5/14 — autentifikacioni neuspesi vracaju 401, ne
+     * generic 400 (Bug T1-001/002/005/012 prijavljen 12.05.2026 manuelnim
+     * testiranjem). Mora biti pre handleRuntimeException jer
+     * AuthenticationFailedException extends RuntimeException — Spring bira
+     * najspecifičniji handler.
+     */
+    @ExceptionHandler(AuthenticationFailedException.class)
+    public ResponseEntity<MessageResponseDto> handleAuthenticationFailed(AuthenticationFailedException ex) {
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(new MessageResponseDto(ex.getMessage()));
+    }
+
+    /**
+     * Account lockout posle 5 neuspeha — takodje mora biti pre RuntimeException
+     * handler-a. Vraca 401 (sa SR porukom — vidi {@code AccountLockoutService}).
+     */
+    @ExceptionHandler(AccountLockoutService.AccountLockedException.class)
+    public ResponseEntity<MessageResponseDto> handleAccountLocked(AccountLockoutService.AccountLockedException ex) {
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
                 .body(new MessageResponseDto(ex.getMessage()));
     }
 

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/auth/config/GlobalSecurityConfig.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/auth/config/GlobalSecurityConfig.java
@@ -62,6 +62,7 @@ public class GlobalSecurityConfig  {
                                 "/auth/refresh",
                                 "/auth/logout",
                                 "/auth-employee/activate",
+                                "/auth-employee/activation-token/*/status",
                                 "/swagger-ui.html",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/auth/config/GlobalSecurityConfig.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/auth/config/GlobalSecurityConfig.java
@@ -142,6 +142,17 @@ public class GlobalSecurityConfig  {
                                 .hasAuthority("ROLE_INTERBANK")
                         // Arbitro asistent — svi autentifikovani korisnici (klijenti + zaposleni)
                         .requestMatchers("/assistant/**").authenticated()
+                        // Stedna knjizica (Celina 2): klijentske rute su authenticated,
+                        // admin rute zahtevaju ADMIN ili SUPERVISOR rolu.
+                        // /admin/savings/** mora biti PRE anyRequest da uzme prednost.
+                        .requestMatchers(HttpMethod.POST, "/savings/deposits").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/savings/deposits/my").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/savings/deposits/*").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/savings/deposits/*/transactions").authenticated()
+                        .requestMatchers(HttpMethod.PATCH, "/savings/deposits/*/auto-renew").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/savings/deposits/*/withdraw-early").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/savings/rates").authenticated()
+                        .requestMatchers("/admin/savings/**").hasAnyAuthority("ROLE_ADMIN", "ADMIN", "SUPERVISOR")
                         .anyRequest().authenticated()
                 )
                 .formLogin(AbstractHttpConfigurer::disable)

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/auth/exception/AuthenticationFailedException.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/auth/exception/AuthenticationFailedException.java
@@ -1,0 +1,20 @@
+package rs.raf.banka2_bek.auth.exception;
+
+/**
+ * Bacaja se kad authentikacija ne uspe (pogresan email, pogresna lozinka,
+ * neaktivan nalog). Mapira se na HTTP 401 Unauthorized u {@code GlobalExceptionHandler}.
+ *
+ * Spec Celina 1, Sc 2/3/5/14: login pokusaji sa nevalidnim kredencijalima
+ * ili na deaktiviranom nalogu treba da vracaju autentifikacionu gresku, ne
+ * generic 400 Bad Request (Bug T1-001/002/005/012 prijavljen 12.05.2026).
+ *
+ * Sec note: poruka treba da bude GENERIC ("Neispravni unos") da ne otkriva
+ * da li email postoji u sistemu. Ovo se primenjuje za pogresnu lozinku +
+ * nepostojeci email. Za deaktiviran nalog ostavljamo informativnu poruku
+ * jer korisnik ionako mora da kontaktira admin-a za reaktivaciju.
+ */
+public class AuthenticationFailedException extends RuntimeException {
+    public AuthenticationFailedException(String message) {
+        super(message);
+    }
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/auth/service/AccountLockoutService.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/auth/service/AccountLockoutService.java
@@ -62,6 +62,9 @@ public class AccountLockoutService {
     /**
      * Baca {@link AccountLockedException} ako je email trenutno lock-ovan.
      * Treba pozvati pre nego sto se proveri lozinka.
+     *
+     * Poruka je na srpskom (Bug T1-017 — pre fix-a poruka je bila pomesana
+     * SR/EN sto je FE prosledjivao 1:1 korisniku).
      */
     public void assertNotLocked(String email) {
         if (email == null) return;
@@ -69,14 +72,19 @@ public class AccountLockoutService {
         Instant locked = lockedUntil.getIfPresent(key);
         if (locked != null && locked.isAfter(Instant.now())) {
             long secondsRemaining = locked.getEpochSecond() - Instant.now().getEpochSecond();
-            throw new AccountLockedException(
-                    "Account temporarily locked due to too many failed attempts; try again in "
-                    + (secondsRemaining / 60 + 1) + " min", secondsRemaining);
+            throw new AccountLockedException(formatLockoutMessage(secondsRemaining), secondsRemaining);
         }
     }
 
     /**
      * Belezi neuspesan pokusaj i lockuje racun ako je dosegnut prag.
+     *
+     * Spec Sc 5 (Bug T1-015): "posle 4 neuspeha, 5. pokusaj zakljucava nalog".
+     * Stari kod je samo postavljao lock na 5. pokusaju ali vracao genericku
+     * gresku "Invalid email or password" — korisnik je dobijao lockout alert
+     * tek na 6. pokusaju kad je {@code assertNotLocked} pucao. Sad bacamo
+     * {@link AccountLockedException} odmah kad pretreknemo prag, tako da
+     * korisnik vidi lockout poruku na samom 5. pokusaju.
      */
     public void recordFailure(String email) {
         if (email == null) return;
@@ -84,10 +92,19 @@ public class AccountLockoutService {
         AtomicInteger count = failedAttempts.get(key, k -> new AtomicInteger(0));
         int attempts = count.incrementAndGet();
         if (attempts >= maxFailedAttempts) {
-            lockedUntil.put(key, Instant.now().plus(Duration.ofMinutes(lockDurationMinutes)));
+            Instant lockUntil = Instant.now().plus(Duration.ofMinutes(lockDurationMinutes));
+            lockedUntil.put(key, lockUntil);
             failedAttempts.invalidate(key);
             log.warn("Account locked: {} ({} failed attempts)", key, attempts);
+            long secondsRemaining = lockUntil.getEpochSecond() - Instant.now().getEpochSecond();
+            throw new AccountLockedException(formatLockoutMessage(secondsRemaining), secondsRemaining);
         }
+    }
+
+    private String formatLockoutMessage(long secondsRemaining) {
+        long minutes = Math.max(1, secondsRemaining / 60 + 1);
+        return "Nalog je privremeno zakljucan zbog previse neuspesnih pokusaja. "
+                + "Pokusajte ponovo za " + minutes + " min.";
     }
 
     /**

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/auth/service/AuthService.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/auth/service/AuthService.java
@@ -12,6 +12,7 @@ import rs.raf.banka2_bek.account.model.AccountType;
 import rs.raf.banka2_bek.account.repository.AccountRepository;
 import rs.raf.banka2_bek.account.util.AccountNumberUtils;
 import rs.raf.banka2_bek.auth.dto.*;
+import rs.raf.banka2_bek.auth.exception.AuthenticationFailedException;
 import rs.raf.banka2_bek.auth.model.PasswordResetRequestedEvent;
 import rs.raf.banka2_bek.auth.model.PasswordResetToken;
 import rs.raf.banka2_bek.auth.model.User;
@@ -181,8 +182,7 @@ public class AuthService {
 
     public AuthResponseDto login(LoginRequestDto request) {
         // Opciono.2 — proveri lockout pre nego sto se proveri lozinka.
-        // Bacaja AccountLockedException ako je email lock-ovan (vidi
-        // AuthService client error handling u GlobalExceptionHandler-u).
+        // Bacaja AccountLockedException ako je email lock-ovan; mapira se u 401.
         accountLockoutService.assertNotLocked(request.getEmail());
 
         // First, try to find an employee with this email
@@ -194,7 +194,9 @@ public class AuthService {
             String salt = employee.getSaltPassword();
             if (passwordEncoder.matches(request.getPassword() + salt, employee.getPassword())) {
                 if (!Boolean.TRUE.equals(employee.getActive())) {
-                    throw new RuntimeException("Employee account is not active");
+                    // Spec Sc 14 — login deaktiviranog naloga vraca 401, ne 400
+                    // (Bug T1-012 prijavljen 12.05.2026).
+                    throw new AuthenticationFailedException("Nalog je deaktiviran.");
                 }
 
                 accountLockoutService.recordSuccess(request.getEmail());
@@ -211,7 +213,9 @@ public class AuthService {
 
             if (passwordEncoder.matches(request.getPassword(), user.getPassword())) {
                 if (!user.isActive()) {
-                    throw new RuntimeException("User account is not active");
+                    // Isto kao employee — generic poruka ne otkriva da li email
+                    // postoji ili je deaktiviran. Vraca 401.
+                    throw new AuthenticationFailedException("Nalog je deaktiviran.");
                 }
 
                 accountLockoutService.recordSuccess(request.getEmail());
@@ -222,8 +226,13 @@ public class AuthService {
         }
 
         // Neither employee nor user found, or password didn't match — broji failure.
+        // Spec Sc 5: posle 4 neuspeha, 5. pokusaj zakljucava nalog. AccountLockoutService
+        // sad baca AccountLockedException u istom pozivu kad pretreknemo prag — tako
+        // korisnik dobija lockout poruku na 5. pokusaju (Bug T1-015), ne tek na 6.
         accountLockoutService.recordFailure(request.getEmail());
-        throw new RuntimeException("Invalid email or password");
+        // Spec Sc 2/3: 401 sa generic porukom "Neispravni unos" (poruka na SR jer
+        // ostatak UI je na SR — Bug T1-017 mesan SR/EN).
+        throw new AuthenticationFailedException("Neispravan email ili lozinka.");
     }
 
     public String requestPasswordReset(PasswordResetRequestDto request) {

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/employee/controller/EmployeeAuthController.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/employee/controller/EmployeeAuthController.java
@@ -7,11 +7,14 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import rs.raf.banka2_bek.employee.dto.ActivateAccountRequestDto;
+import rs.raf.banka2_bek.employee.dto.ActivationTokenStatusDto;
 import rs.raf.banka2_bek.employee.service.EmployeeAuthService;
 
 import java.util.Map;
@@ -33,5 +36,20 @@ public class EmployeeAuthController {
     public ResponseEntity<Map<String, String>> activate(@Valid @RequestBody ActivateAccountRequestDto request) {
         employeeAuthService.activateAccount(request.getToken(), request.getPassword());
         return ResponseEntity.ok(Map.of("message", "Account activated successfully"));
+    }
+
+    /**
+     * Spec Sc 9 + ad-hoc bag 12.05.2026: FE pre-check stanja tokena pre
+     * renderovanja forme za aktivaciju. Endpoint je javan (bez auth-a) —
+     * tokens su sami po sebi tajni (~UUID-4, 128-bit entropy).
+     */
+    @Operation(summary = "Activation token status",
+            description = "Returns the current status of an activation token (VALID/USED/EXPIRED/INVALID/ALREADY_ACTIVE) without consuming it.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Status returned")
+    })
+    @GetMapping("/activation-token/{token}/status")
+    public ResponseEntity<ActivationTokenStatusDto> tokenStatus(@PathVariable("token") String token) {
+        return ResponseEntity.ok(employeeAuthService.getTokenStatus(token));
     }
 }

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/employee/dto/ActivationTokenStatusDto.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/employee/dto/ActivationTokenStatusDto.java
@@ -1,0 +1,34 @@
+package rs.raf.banka2_bek.employee.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * Vraca trenutno stanje aktivacionog tokena za FE da bi mogao da odluci
+ * sta da prikaze pre nego sto user popuni formu.
+ *
+ * Spec Celina 1 Sc 9 + ad-hoc bag prijavljen 12.05.2026 ("FE dozvoljava
+ * reotvaranje forme za aktivaciju naloga nakon sto je activation token vec
+ * iskoriscen"). Pre fix-a, FE je uvek renderovao formu cim postoji `token`
+ * query param, pa korisnik moze prosto da osvezi stranicu i ponovo pokusa
+ * aktivaciju iako je nalog vec aktiviran (BE bi vratio 400 ali korisnik je
+ * imao formu pred sobom).
+ *
+ * `status` enum-like polje: VALID / USED / EXPIRED / INVALID / ALREADY_ACTIVE.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ActivationTokenStatusDto {
+    /** Jedna od vrednosti: VALID, USED, EXPIRED, INVALID, ALREADY_ACTIVE. */
+    private String status;
+    /** Trenutak isteka tokena (null ako je INVALID). */
+    private LocalDateTime expiresAt;
+    /** Email vlasnika tokena radi prikaza (null ako je INVALID, sigurnosno minimalno). */
+    private String email;
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/employee/service/EmployeeAuthService.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/employee/service/EmployeeAuthService.java
@@ -1,5 +1,7 @@
 package rs.raf.banka2_bek.employee.service;
 
+import rs.raf.banka2_bek.employee.dto.ActivationTokenStatusDto;
+
 /**
  * Service for authentication and account activation.
  */
@@ -16,4 +18,15 @@ public interface EmployeeAuthService {
      * @throws IllegalStateException    if the account is already active
      */
     void activateAccount(String tokenValue, String newPassword);
+
+    /**
+     * Vraca stanje aktivacionog tokena. FE poziva ovo na mount-u
+     * {@code ActivateAccountPage} da bi sprecio renderovanje forme kad
+     * je token vec iskoriscen ili istekao (Bug Scenario 9 Tim 1).
+     *
+     * Nikad ne baca exception — uvek vrati DTO sa statusom (VALID, USED,
+     * EXPIRED, INVALID, ALREADY_ACTIVE). Endpoint je javan (bez auth-a)
+     * jer ga zove neaktivirani zaposleni preko email linka.
+     */
+    ActivationTokenStatusDto getTokenStatus(String tokenValue);
 }

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/employee/service/implementation/EmployeeAuthServiceImpl.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/employee/service/implementation/EmployeeAuthServiceImpl.java
@@ -5,6 +5,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import rs.raf.banka2_bek.employee.dto.ActivationTokenStatusDto;
 import rs.raf.banka2_bek.employee.event.EmployeeActivationConfirmationEvent;
 import rs.raf.banka2_bek.employee.model.ActivationToken;
 import rs.raf.banka2_bek.employee.model.Employee;
@@ -13,6 +14,7 @@ import rs.raf.banka2_bek.employee.repository.EmployeeRepository;
 import rs.raf.banka2_bek.employee.service.EmployeeAuthService;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 /**
  * Implementation of {@link EmployeeAuthService}.
@@ -61,5 +63,62 @@ public class EmployeeAuthServiceImpl implements EmployeeAuthService {
         activationTokenRepository.save(token);
 
         eventPublisher.publishEvent(new EmployeeActivationConfirmationEvent(this, employee.getEmail(), employee.getFirstName()));
+    }
+
+    /**
+     * Spec Sc 9 + ad-hoc bag 12.05.2026: vraca stanje tokena bez bacanja
+     * izuzetka, tako da FE moze da pre-check-uje pre renderovanja forme.
+     *
+     * Status redosled provere odgovara redosledu u {@link #activateAccount}:
+     *   1) Token ne postoji  → INVALID
+     *   2) used || invalidated → USED
+     *   3) expiresAt < now → EXPIRED
+     *   4) employee.active == true → ALREADY_ACTIVE (token jos validan ali nalog je vec aktivan)
+     *   5) Sve OK → VALID
+     */
+    @Override
+    public ActivationTokenStatusDto getTokenStatus(String tokenValue) {
+        if (tokenValue == null || tokenValue.isBlank()) {
+            return ActivationTokenStatusDto.builder().status("INVALID").build();
+        }
+        Optional<ActivationToken> opt = activationTokenRepository.findByToken(tokenValue);
+        if (opt.isEmpty()) {
+            return ActivationTokenStatusDto.builder().status("INVALID").build();
+        }
+        ActivationToken token = opt.get();
+
+        if (token.isUsed() || token.isInvalidated()) {
+            // Vracamo email (radi UX-a — "ovaj nalog je vec aktiviran") ali se
+            // status razlikuje od ALREADY_ACTIVE jer je u ovom slucaju token
+            // potrosen, FE moze prikazati "Link za aktivaciju je vec iskoriscen".
+            Employee emp = token.getEmployee();
+            return ActivationTokenStatusDto.builder()
+                    .status("USED")
+                    .expiresAt(token.getExpiresAt())
+                    .email(emp != null ? emp.getEmail() : null)
+                    .build();
+        }
+
+        if (token.getExpiresAt().isBefore(LocalDateTime.now())) {
+            return ActivationTokenStatusDto.builder()
+                    .status("EXPIRED")
+                    .expiresAt(token.getExpiresAt())
+                    .build();
+        }
+
+        Employee employee = token.getEmployee();
+        if (employee != null && Boolean.TRUE.equals(employee.getActive())) {
+            return ActivationTokenStatusDto.builder()
+                    .status("ALREADY_ACTIVE")
+                    .expiresAt(token.getExpiresAt())
+                    .email(employee.getEmail())
+                    .build();
+        }
+
+        return ActivationTokenStatusDto.builder()
+                .status("VALID")
+                .expiresAt(token.getExpiresAt())
+                .email(employee != null ? employee.getEmail() : null)
+                .build();
     }
 }

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/employee/service/implementation/EmployeeServiceImpl.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/employee/service/implementation/EmployeeServiceImpl.java
@@ -112,11 +112,18 @@ public class EmployeeServiceImpl implements EmployeeService {
             throw new IllegalStateException("Admin employees cannot be edited.");
         }
 
-        if (request.getEmail() != null) {
-            if (employeeRepository.existsByEmailAndIdNot(request.getEmail(), id)) {
-                throw new IllegalArgumentException("An employee with this email already exists.");
-            }
-            employee.setEmail(request.getEmail());
+        // Spec §30 dozvoljava izmenu "svih informacija osim ID-a i passworda",
+        // ALI email je identitet (login key, references u tokenima, audit log
+        // co-Author trail) — Plan_Manuelnog_Testiranja.pdf i T1-009/T1-010
+        // bug izvestaj traze read-only ponasanje. Defense-in-depth: kad neko
+        // posalje PUT sa drugacijim email-om (npr. zaobilazi disabled FE polje
+        // ili udje direktno na API), tihi no-op — ne ruzimo idempotent request
+        // sa istim email-om ali odbijamo promenu. Razlog za 400 umesto tihog
+        // ignore-a: FE mora videti da je akcija neuspela inace bi user mislio
+        // da je promenio email pa ne moze posle da se uloguje sa starim.
+        if (request.getEmail() != null && !request.getEmail().equals(employee.getEmail())) {
+            throw new IllegalArgumentException(
+                    "Email zaposlenog se ne moze menjati. Email je identifikator naloga.");
         }
 
         if (request.getFirstName() != null) employee.setFirstName(request.getFirstName());

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/controller/SavingsAdminController.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/controller/SavingsAdminController.java
@@ -1,0 +1,45 @@
+package rs.raf.banka2_bek.savings.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import rs.raf.banka2_bek.savings.dto.*;
+import rs.raf.banka2_bek.savings.entity.SavingsDepositStatus;
+import rs.raf.banka2_bek.savings.service.SavingsAdminService;
+import rs.raf.banka2_bek.savings.service.SavingsInterestRateService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/admin/savings")
+@RequiredArgsConstructor
+public class SavingsAdminController {
+
+    private final SavingsAdminService adminService;
+    private final SavingsInterestRateService rateService;
+
+    @GetMapping("/deposits")
+    public ResponseEntity<Page<SavingsDepositDto>> listAll(
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) Long clientId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        SavingsDepositStatus statusEnum = status != null ? SavingsDepositStatus.valueOf(status) : null;
+        Pageable pageable = PageRequest.of(page, size);
+        return ResponseEntity.ok(adminService.listAll(statusEnum, clientId, pageable));
+    }
+
+    @GetMapping("/rates")
+    public ResponseEntity<List<SavingsRateDto>> listAllRates() {
+        return ResponseEntity.ok(rateService.listAll());
+    }
+
+    @PostMapping("/rates")
+    public ResponseEntity<SavingsRateDto> upsertRate(@Valid @RequestBody UpsertSavingsRateDto dto) {
+        return ResponseEntity.ok(rateService.upsert(dto));
+    }
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/controller/SavingsDepositController.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/controller/SavingsDepositController.java
@@ -1,0 +1,58 @@
+package rs.raf.banka2_bek.savings.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import rs.raf.banka2_bek.savings.dto.*;
+import rs.raf.banka2_bek.savings.service.SavingsDepositService;
+import rs.raf.banka2_bek.savings.service.SavingsInterestRateService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/savings")
+@RequiredArgsConstructor
+public class SavingsDepositController {
+
+    private final SavingsDepositService depositService;
+    private final SavingsInterestRateService rateService;
+
+    @PostMapping("/deposits")
+    public ResponseEntity<SavingsDepositDto> openDeposit(@Valid @RequestBody OpenDepositDto dto) {
+        return ResponseEntity.ok(depositService.openDeposit(dto));
+    }
+
+    @GetMapping("/deposits/my")
+    public ResponseEntity<List<SavingsDepositDto>> listMy() {
+        return ResponseEntity.ok(depositService.listMyDeposits());
+    }
+
+    @GetMapping("/deposits/{id}")
+    public ResponseEntity<SavingsDepositDto> getDeposit(@PathVariable Long id) {
+        return ResponseEntity.ok(depositService.getDeposit(id));
+    }
+
+    @GetMapping("/deposits/{id}/transactions")
+    public ResponseEntity<List<SavingsTransactionDto>> getTransactions(@PathVariable Long id) {
+        return ResponseEntity.ok(depositService.listDepositTransactions(id));
+    }
+
+    @PatchMapping("/deposits/{id}/auto-renew")
+    public ResponseEntity<SavingsDepositDto> toggleAutoRenew(@PathVariable Long id,
+                                                              @Valid @RequestBody ToggleAutoRenewDto dto) {
+        return ResponseEntity.ok(depositService.toggleAutoRenew(id, dto));
+    }
+
+    @PostMapping("/deposits/{id}/withdraw-early")
+    public ResponseEntity<SavingsDepositDto> withdrawEarly(@PathVariable Long id,
+                                                            @Valid @RequestBody WithdrawEarlyDto dto) {
+        return ResponseEntity.ok(depositService.withdrawEarly(id, dto));
+    }
+
+    @GetMapping("/rates")
+    public ResponseEntity<List<SavingsRateDto>> getRates(
+            @RequestParam(required = false) String currency) {
+        return ResponseEntity.ok(rateService.listActive(currency));
+    }
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/dto/OpenDepositDto.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/dto/OpenDepositDto.java
@@ -1,0 +1,31 @@
+package rs.raf.banka2_bek.savings.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.*;
+import java.math.BigDecimal;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class OpenDepositDto {
+
+    @NotNull
+    private Long sourceAccountId;
+
+    @NotNull
+    private Long linkedAccountId;
+
+    @NotNull
+    @DecimalMin(value = "0.01", message = "Iznos mora biti pozitivan")
+    private BigDecimal principalAmount;
+
+    @NotNull
+    @Min(value = 3, message = "Rok mora biti najmanje 3 meseca")
+    @Max(value = 36, message = "Rok mora biti najvise 36 meseci")
+    private Integer termMonths;
+
+    @NotNull
+    private Boolean autoRenew;
+
+    @NotBlank(message = "OTP kod je obavezan")
+    @Size(min = 6, max = 6, message = "OTP kod mora imati 6 cifara")
+    private String otpCode;
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/dto/SavingsDepositDto.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/dto/SavingsDepositDto.java
@@ -1,0 +1,27 @@
+package rs.raf.banka2_bek.savings.dto;
+
+import lombok.*;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class SavingsDepositDto {
+    private Long id;
+    private Long clientId;
+    private String clientName;
+    private Long linkedAccountId;
+    private String linkedAccountNumber;
+    private BigDecimal principalAmount;
+    private String currencyCode;
+    private Integer termMonths;
+    private BigDecimal annualInterestRate;
+    private LocalDate startDate;
+    private LocalDate maturityDate;
+    private LocalDate nextInterestPaymentDate;
+    private BigDecimal totalInterestPaid;
+    private Boolean autoRenew;
+    private String status;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/dto/SavingsRateDto.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/dto/SavingsRateDto.java
@@ -1,0 +1,15 @@
+package rs.raf.banka2_bek.savings.dto;
+
+import lombok.*;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class SavingsRateDto {
+    private Long id;
+    private String currencyCode;
+    private Integer termMonths;
+    private BigDecimal annualRate;
+    private Boolean active;
+    private LocalDate effectiveFrom;
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/dto/SavingsTransactionDto.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/dto/SavingsTransactionDto.java
@@ -1,0 +1,19 @@
+package rs.raf.banka2_bek.savings.dto;
+
+import lombok.*;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class SavingsTransactionDto {
+    private Long id;
+    private Long depositId;
+    private String type;
+    private BigDecimal amount;
+    private String currencyCode;
+    private LocalDate processedDate;
+    private Long resultingTransactionId;
+    private String description;
+    private LocalDateTime createdAt;
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/dto/ToggleAutoRenewDto.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/dto/ToggleAutoRenewDto.java
@@ -1,0 +1,10 @@
+package rs.raf.banka2_bek.savings.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor
+public class ToggleAutoRenewDto {
+    @NotNull
+    private Boolean autoRenew;
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/dto/UpsertSavingsRateDto.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/dto/UpsertSavingsRateDto.java
@@ -1,0 +1,19 @@
+package rs.raf.banka2_bek.savings.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.*;
+import java.math.BigDecimal;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor
+public class UpsertSavingsRateDto {
+    @NotBlank
+    private String currencyCode;
+
+    @NotNull @Min(3) @Max(36)
+    private Integer termMonths;
+
+    @NotNull
+    @DecimalMin(value = "0.0", inclusive = false)
+    @DecimalMax(value = "50.0", message = "Maksimalna stopa je 50% p.a.")
+    private BigDecimal annualRate;
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/dto/WithdrawEarlyDto.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/dto/WithdrawEarlyDto.java
@@ -1,0 +1,11 @@
+package rs.raf.banka2_bek.savings.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor
+public class WithdrawEarlyDto {
+    @NotBlank
+    @Size(min = 6, max = 6)
+    private String otpCode;
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/entity/SavingsDeposit.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/entity/SavingsDeposit.java
@@ -1,0 +1,75 @@
+package rs.raf.banka2_bek.savings.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import rs.raf.banka2_bek.currency.model.Currency;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "savings_deposits")
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SavingsDeposit {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "client_id", nullable = false)
+    private Long clientId;
+
+    @Column(name = "linked_account_id", nullable = false)
+    private Long linkedAccountId;
+
+    @Column(name = "principal_amount", nullable = false, precision = 19, scale = 4)
+    private BigDecimal principalAmount;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "currency_id", nullable = false)
+    private Currency currency;
+
+    @Column(name = "term_months", nullable = false)
+    private Integer termMonths;
+
+    @Column(name = "annual_interest_rate", nullable = false, precision = 5, scale = 2)
+    private BigDecimal annualInterestRate;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "maturity_date", nullable = false)
+    private LocalDate maturityDate;
+
+    @Column(name = "next_interest_payment_date", nullable = false)
+    private LocalDate nextInterestPaymentDate;
+
+    @Column(name = "total_interest_paid", nullable = false, precision = 19, scale = 4)
+    @ColumnDefault("0")
+    private BigDecimal totalInterestPaid;
+
+    @Column(name = "auto_renew", nullable = false)
+    @ColumnDefault("0")
+    private Boolean autoRenew;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    private SavingsDepositStatus status;
+
+    @Version
+    private Long version;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/entity/SavingsDepositStatus.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/entity/SavingsDepositStatus.java
@@ -1,0 +1,8 @@
+package rs.raf.banka2_bek.savings.entity;
+
+public enum SavingsDepositStatus {
+    ACTIVE,
+    MATURED,
+    WITHDRAWN_EARLY,
+    RENEWED
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/entity/SavingsInterestRate.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/entity/SavingsInterestRate.java
@@ -11,7 +11,13 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "savings_interest_rates")
+@Table(
+    name = "savings_interest_rates",
+    uniqueConstraints = @UniqueConstraint(
+        name = "uk_savings_rates_currency_term_active",
+        columnNames = {"currency_id", "term_months", "active"}
+    )
+)
 @Getter @Setter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/entity/SavingsInterestRate.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/entity/SavingsInterestRate.java
@@ -1,0 +1,44 @@
+package rs.raf.banka2_bek.savings.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.CreationTimestamp;
+import rs.raf.banka2_bek.currency.model.Currency;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "savings_interest_rates")
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SavingsInterestRate {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "currency_id", nullable = false)
+    private Currency currency;
+
+    @Column(name = "term_months", nullable = false)
+    private Integer termMonths;
+
+    @Column(name = "annual_rate", nullable = false, precision = 5, scale = 2)
+    private BigDecimal annualRate;
+
+    @Column(nullable = false)
+    @ColumnDefault("1")
+    private Boolean active;
+
+    @Column(name = "effective_from", nullable = false)
+    private LocalDate effectiveFrom;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/entity/SavingsTransaction.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/entity/SavingsTransaction.java
@@ -1,0 +1,50 @@
+package rs.raf.banka2_bek.savings.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import rs.raf.banka2_bek.currency.model.Currency;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "savings_transactions")
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SavingsTransaction {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "deposit_id", nullable = false)
+    private SavingsDeposit deposit;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 64)
+    private SavingsTransactionType type;
+
+    @Column(nullable = false, precision = 19, scale = 4)
+    private BigDecimal amount;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "currency_id", nullable = false)
+    private Currency currency;
+
+    @Column(name = "processed_date", nullable = false)
+    private LocalDate processedDate;
+
+    @Column(name = "resulting_transaction_id")
+    private Long resultingTransactionId;
+
+    @Column(length = 500)
+    private String description;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/entity/SavingsTransactionType.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/entity/SavingsTransactionType.java
@@ -1,0 +1,10 @@
+package rs.raf.banka2_bek.savings.entity;
+
+public enum SavingsTransactionType {
+    OPEN,
+    INTEREST_PAYMENT,
+    PRINCIPAL_RETURN,
+    EARLY_WITHDRAWAL_PRINCIPAL,
+    EARLY_WITHDRAWAL_PENALTY,
+    RENEWAL_OPEN
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/exception/SavingsDepositNotFoundException.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/exception/SavingsDepositNotFoundException.java
@@ -1,0 +1,19 @@
+package rs.raf.banka2_bek.savings.exception;
+
+/**
+ * Bacaj kad korisnik trazi stedni depozit koji ne postoji (po id-u). Mapira se
+ * u HTTP 404 Not Found preko {@link SavingsExceptionHandler}.
+ *
+ * Razdvojen od {@link IllegalArgumentException} (koji ide u 400 Bad Request) da
+ * bi FE mogao da razlikuje "ne postoji" od "los input".
+ */
+public class SavingsDepositNotFoundException extends RuntimeException {
+
+    public SavingsDepositNotFoundException(Long depositId) {
+        super("Depozit ne postoji: id=" + depositId);
+    }
+
+    public SavingsDepositNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/exception/SavingsExceptionHandler.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/exception/SavingsExceptionHandler.java
@@ -1,0 +1,27 @@
+package rs.raf.banka2_bek.savings.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.util.Map;
+
+@ControllerAdvice(basePackages = "rs.raf.banka2_bek.savings.controller")
+public class SavingsExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> handleBadRequest(IllegalArgumentException ex) {
+        return ResponseEntity.badRequest().body(Map.of("message", ex.getMessage()));
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<Map<String, String>> handleForbidden(AccessDeniedException ex) {
+        return ResponseEntity.status(403).body(Map.of("message", ex.getMessage()));
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<Map<String, String>> handleConflict(IllegalStateException ex) {
+        return ResponseEntity.status(500).body(Map.of("message", ex.getMessage()));
+    }
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/exception/SavingsExceptionHandler.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/exception/SavingsExceptionHandler.java
@@ -10,6 +10,11 @@ import java.util.Map;
 @ControllerAdvice(basePackages = "rs.raf.banka2_bek.savings.controller")
 public class SavingsExceptionHandler {
 
+    @ExceptionHandler(SavingsDepositNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleNotFound(SavingsDepositNotFoundException ex) {
+        return ResponseEntity.status(404).body(Map.of("message", ex.getMessage()));
+    }
+
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Map<String, String>> handleBadRequest(IllegalArgumentException ex) {
         return ResponseEntity.badRequest().body(Map.of("message", ex.getMessage()));

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/mapper/SavingsMapper.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/mapper/SavingsMapper.java
@@ -1,0 +1,74 @@
+package rs.raf.banka2_bek.savings.mapper;
+
+import org.springframework.stereotype.Component;
+import rs.raf.banka2_bek.account.model.Account;
+import rs.raf.banka2_bek.account.repository.AccountRepository;
+import rs.raf.banka2_bek.auth.util.UserResolver;
+import rs.raf.banka2_bek.auth.util.UserRole;
+import rs.raf.banka2_bek.savings.dto.*;
+import rs.raf.banka2_bek.savings.entity.*;
+
+@Component
+public class SavingsMapper {
+
+    private final AccountRepository accountRepository;
+    private final UserResolver userResolver;
+
+    public SavingsMapper(AccountRepository accountRepository, UserResolver userResolver) {
+        this.accountRepository = accountRepository;
+        this.userResolver = userResolver;
+    }
+
+    public SavingsDepositDto toDepositDto(SavingsDeposit d) {
+        if (d == null) return null;
+        String accountNumber = accountRepository.findById(d.getLinkedAccountId())
+                .map(Account::getAccountNumber).orElse(null);
+        String clientName = userResolver.resolveName(d.getClientId(), UserRole.CLIENT);
+        return SavingsDepositDto.builder()
+                .id(d.getId())
+                .clientId(d.getClientId())
+                .clientName(clientName)
+                .linkedAccountId(d.getLinkedAccountId())
+                .linkedAccountNumber(accountNumber)
+                .principalAmount(d.getPrincipalAmount())
+                .currencyCode(d.getCurrency().getCode())
+                .termMonths(d.getTermMonths())
+                .annualInterestRate(d.getAnnualInterestRate())
+                .startDate(d.getStartDate())
+                .maturityDate(d.getMaturityDate())
+                .nextInterestPaymentDate(d.getNextInterestPaymentDate())
+                .totalInterestPaid(d.getTotalInterestPaid())
+                .autoRenew(d.getAutoRenew())
+                .status(d.getStatus().name())
+                .createdAt(d.getCreatedAt())
+                .updatedAt(d.getUpdatedAt())
+                .build();
+    }
+
+    public SavingsTransactionDto toTransactionDto(SavingsTransaction t) {
+        if (t == null) return null;
+        return SavingsTransactionDto.builder()
+                .id(t.getId())
+                .depositId(t.getDeposit().getId())
+                .type(t.getType().name())
+                .amount(t.getAmount())
+                .currencyCode(t.getCurrency().getCode())
+                .processedDate(t.getProcessedDate())
+                .resultingTransactionId(t.getResultingTransactionId())
+                .description(t.getDescription())
+                .createdAt(t.getCreatedAt())
+                .build();
+    }
+
+    public SavingsRateDto toRateDto(SavingsInterestRate r) {
+        if (r == null) return null;
+        return SavingsRateDto.builder()
+                .id(r.getId())
+                .currencyCode(r.getCurrency().getCode())
+                .termMonths(r.getTermMonths())
+                .annualRate(r.getAnnualRate())
+                .active(r.getActive())
+                .effectiveFrom(r.getEffectiveFrom())
+                .build();
+    }
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/repository/SavingsDepositRepository.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/repository/SavingsDepositRepository.java
@@ -1,0 +1,34 @@
+package rs.raf.banka2_bek.savings.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import rs.raf.banka2_bek.savings.entity.SavingsDeposit;
+import rs.raf.banka2_bek.savings.entity.SavingsDepositStatus;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface SavingsDepositRepository extends JpaRepository<SavingsDeposit, Long> {
+
+    List<SavingsDeposit> findByClientIdOrderByCreatedAtDesc(Long clientId);
+
+    List<SavingsDeposit> findByStatusAndNextInterestPaymentDateLessThanEqual(
+        SavingsDepositStatus status, LocalDate date);
+
+    List<SavingsDeposit> findByStatusAndMaturityDateLessThanEqual(
+        SavingsDepositStatus status, LocalDate date);
+
+    @Query("""
+        SELECT d FROM SavingsDeposit d
+        WHERE (:status IS NULL OR d.status = :status)
+          AND (:clientId IS NULL OR d.clientId = :clientId)
+        ORDER BY d.createdAt DESC
+        """)
+    Page<SavingsDeposit> adminFindAll(
+        @Param("status") SavingsDepositStatus status,
+        @Param("clientId") Long clientId,
+        Pageable pageable);
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/repository/SavingsInterestRateRepository.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/repository/SavingsInterestRateRepository.java
@@ -1,0 +1,27 @@
+package rs.raf.banka2_bek.savings.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import rs.raf.banka2_bek.savings.entity.SavingsInterestRate;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SavingsInterestRateRepository extends JpaRepository<SavingsInterestRate, Long> {
+
+    @Query("""
+        SELECT r FROM SavingsInterestRate r
+        WHERE r.currency.id = :currencyId
+          AND r.termMonths = :termMonths
+          AND r.active = true
+        """)
+    Optional<SavingsInterestRate> findActive(@Param("currencyId") Long currencyId,
+                                              @Param("termMonths") Integer termMonths);
+
+    @Query("SELECT r FROM SavingsInterestRate r WHERE r.active = true ORDER BY r.currency.code, r.termMonths")
+    List<SavingsInterestRate> findAllActive();
+
+    @Query("SELECT r FROM SavingsInterestRate r WHERE r.currency.code = :code AND r.active = true ORDER BY r.termMonths")
+    List<SavingsInterestRate> findActiveByCurrencyCode(@Param("code") String code);
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/repository/SavingsTransactionRepository.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/repository/SavingsTransactionRepository.java
@@ -1,0 +1,10 @@
+package rs.raf.banka2_bek.savings.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import rs.raf.banka2_bek.savings.entity.SavingsTransaction;
+
+import java.util.List;
+
+public interface SavingsTransactionRepository extends JpaRepository<SavingsTransaction, Long> {
+    List<SavingsTransaction> findByDepositIdOrderByCreatedAtDesc(Long depositId);
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/service/SavingsAdminService.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/service/SavingsAdminService.java
@@ -1,0 +1,24 @@
+package rs.raf.banka2_bek.savings.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import rs.raf.banka2_bek.savings.dto.SavingsDepositDto;
+import rs.raf.banka2_bek.savings.entity.SavingsDepositStatus;
+import rs.raf.banka2_bek.savings.mapper.SavingsMapper;
+import rs.raf.banka2_bek.savings.repository.SavingsDepositRepository;
+
+@Service
+@RequiredArgsConstructor
+public class SavingsAdminService {
+
+    private final SavingsDepositRepository depositRepo;
+    private final SavingsMapper mapper;
+
+    @Transactional(readOnly = true)
+    public Page<SavingsDepositDto> listAll(SavingsDepositStatus status, Long clientId, Pageable pageable) {
+        return depositRepo.adminFindAll(status, clientId, pageable).map(mapper::toDepositDto);
+    }
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/service/SavingsCalculator.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/service/SavingsCalculator.java
@@ -1,0 +1,40 @@
+package rs.raf.banka2_bek.savings.service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+
+/**
+ * Pure utility za izracunavanje kamata i datuma.
+ * Bez Spring zavisnosti, lako se testira sa cistim JUnit testovima.
+ */
+public final class SavingsCalculator {
+
+    private static final BigDecimal MONTHLY_DIVISOR = new BigDecimal("1200");
+    private static final BigDecimal EARLY_WITHDRAWAL_PENALTY_RATE = new BigDecimal("0.01");
+
+    private SavingsCalculator() {}
+
+    /** Mesecna kamata = principal * (annualRate / 100 / 12). */
+    public static BigDecimal monthlyInterest(BigDecimal principal, BigDecimal annualRate) {
+        return principal.multiply(annualRate)
+                .divide(MONTHLY_DIVISOR, 4, RoundingMode.HALF_UP);
+    }
+
+    /** Ukupna kamata tokom celokupnog roka. */
+    public static BigDecimal totalInterestOverTerm(BigDecimal principal,
+                                                    BigDecimal annualRate,
+                                                    int termMonths) {
+        return monthlyInterest(principal, annualRate).multiply(BigDecimal.valueOf(termMonths));
+    }
+
+    /** Penal kod razrocenja = 1% glavnice. */
+    public static BigDecimal earlyWithdrawalPenalty(BigDecimal principal) {
+        return principal.multiply(EARLY_WITHDRAWAL_PENALTY_RATE).setScale(4, RoundingMode.HALF_UP);
+    }
+
+    /** Sledeca mesecna isplata: trenutna + 1 mesec (LocalDate.plusMonths handluje 31->28/30 automatski). */
+    public static LocalDate nextMonthlyAnniversary(LocalDate current) {
+        return current.plusMonths(1);
+    }
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/service/SavingsDepositProcessor.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/service/SavingsDepositProcessor.java
@@ -1,0 +1,119 @@
+package rs.raf.banka2_bek.savings.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import rs.raf.banka2_bek.account.model.Account;
+import rs.raf.banka2_bek.account.repository.AccountRepository;
+import rs.raf.banka2_bek.savings.entity.SavingsDeposit;
+import rs.raf.banka2_bek.savings.entity.SavingsDepositStatus;
+import rs.raf.banka2_bek.savings.entity.SavingsInterestRate;
+import rs.raf.banka2_bek.savings.entity.SavingsTransaction;
+import rs.raf.banka2_bek.savings.entity.SavingsTransactionType;
+import rs.raf.banka2_bek.savings.repository.SavingsDepositRepository;
+import rs.raf.banka2_bek.savings.repository.SavingsTransactionRepository;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/**
+ * Procesor pojedinacnih scheduler operacija. Izdvojen iz {@link SavingsScheduler}
+ * tako da {@code @Transactional} prolazi kroz CGLib proxy (intra-class pozivi unutar
+ * istog @Service bean-a ne prolaze kroz proxy, pa ce @Transactional biti ignorisan).
+ *
+ * Tri metode su public i sve sa @Transactional. Scheduler ih poziva preko ovog
+ * bean-a (proxy poziv), tako da svaki invocation ima nezavisnu transakciju.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SavingsDepositProcessor {
+
+    private final SavingsDepositRepository depositRepo;
+    private final SavingsTransactionRepository txRepo;
+    private final SavingsInterestRateService rateService;
+    private final AccountRepository accountRepo;
+
+    @Transactional
+    public void payMonthlyInterest(SavingsDeposit d, LocalDate today) {
+        BigDecimal monthlyInterest = SavingsCalculator.monthlyInterest(
+                d.getPrincipalAmount(), d.getAnnualInterestRate());
+
+        Account linked = accountRepo.findForUpdateById(d.getLinkedAccountId())
+                .orElseThrow(() -> new IllegalStateException("Povezani racun ne postoji"));
+        linked.setBalance(linked.getBalance().add(monthlyInterest));
+        linked.setAvailableBalance(linked.getAvailableBalance().add(monthlyInterest));
+        accountRepo.save(linked);
+
+        d.setTotalInterestPaid(d.getTotalInterestPaid().add(monthlyInterest));
+        d.setNextInterestPaymentDate(SavingsCalculator.nextMonthlyAnniversary(d.getNextInterestPaymentDate()));
+        depositRepo.save(d);
+
+        txRepo.save(SavingsTransaction.builder()
+                .deposit(d).type(SavingsTransactionType.INTEREST_PAYMENT)
+                .amount(monthlyInterest).currency(d.getCurrency()).processedDate(today)
+                .description("Mesecna kamata depozita #" + d.getId())
+                .build());
+
+        log.info("Scheduler: isplacena kamata {} {} za deposit {}",
+                monthlyInterest, d.getCurrency().getCode(), d.getId());
+    }
+
+    @Transactional
+    public void returnPrincipal(SavingsDeposit d, LocalDate today) {
+        Account linked = accountRepo.findForUpdateById(d.getLinkedAccountId())
+                .orElseThrow(() -> new IllegalStateException("Povezani racun ne postoji"));
+        linked.setBalance(linked.getBalance().add(d.getPrincipalAmount()));
+        linked.setAvailableBalance(linked.getAvailableBalance().add(d.getPrincipalAmount()));
+        accountRepo.save(linked);
+
+        d.setStatus(SavingsDepositStatus.MATURED);
+        depositRepo.save(d);
+
+        txRepo.save(SavingsTransaction.builder()
+                .deposit(d).type(SavingsTransactionType.PRINCIPAL_RETURN)
+                .amount(d.getPrincipalAmount()).currency(d.getCurrency()).processedDate(today)
+                .description("Glavnica dospelog depozita #" + d.getId())
+                .build());
+
+        log.info("Scheduler: vracena glavnica {} {} za deposit {}",
+                d.getPrincipalAmount(), d.getCurrency().getCode(), d.getId());
+    }
+
+    @Transactional
+    public void renewDeposit(SavingsDeposit d, LocalDate today) {
+        BigDecimal currentRate = rateService.findActive(d.getCurrency().getId(), d.getTermMonths())
+                .map(SavingsInterestRate::getAnnualRate)
+                .orElseThrow(() -> new IllegalStateException(
+                    "Stopa za auto-obnovu nije dostupna za " + d.getCurrency().getCode()));
+
+        d.setStatus(SavingsDepositStatus.RENEWED);
+        depositRepo.save(d);
+
+        SavingsDeposit renewed = SavingsDeposit.builder()
+                .clientId(d.getClientId())
+                .linkedAccountId(d.getLinkedAccountId())
+                .principalAmount(d.getPrincipalAmount())
+                .currency(d.getCurrency())
+                .termMonths(d.getTermMonths())
+                .annualInterestRate(currentRate)
+                .startDate(today)
+                .maturityDate(today.plusMonths(d.getTermMonths()))
+                .nextInterestPaymentDate(today.plusMonths(1))
+                .totalInterestPaid(BigDecimal.ZERO)
+                .autoRenew(true)
+                .status(SavingsDepositStatus.ACTIVE)
+                .build();
+        renewed = depositRepo.save(renewed);
+
+        txRepo.save(SavingsTransaction.builder()
+                .deposit(renewed).type(SavingsTransactionType.RENEWAL_OPEN)
+                .amount(d.getPrincipalAmount()).currency(d.getCurrency()).processedDate(today)
+                .description("Auto-obnova dospelog depozita #" + d.getId())
+                .build());
+
+        log.info("Scheduler: auto-obnova {} -> {} za client {}",
+                d.getId(), renewed.getId(), d.getClientId());
+    }
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/service/SavingsDepositService.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/service/SavingsDepositService.java
@@ -23,6 +23,7 @@ import rs.raf.banka2_bek.savings.entity.SavingsDepositStatus;
 import rs.raf.banka2_bek.savings.entity.SavingsInterestRate;
 import rs.raf.banka2_bek.savings.entity.SavingsTransaction;
 import rs.raf.banka2_bek.savings.entity.SavingsTransactionType;
+import rs.raf.banka2_bek.savings.exception.SavingsDepositNotFoundException;
 import rs.raf.banka2_bek.savings.mapper.SavingsMapper;
 import rs.raf.banka2_bek.savings.repository.SavingsDepositRepository;
 import rs.raf.banka2_bek.savings.repository.SavingsTransactionRepository;
@@ -163,7 +164,7 @@ public class SavingsDepositService {
     @Transactional(readOnly = true)
     public SavingsDepositDto getDeposit(Long id) {
         SavingsDeposit d = depositRepo.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("Depozit ne postoji"));
+                .orElseThrow(() -> new SavingsDepositNotFoundException(id));
         UserContext me = userResolver.resolveCurrent();
         verifyDepositAccess(d, me);
         return mapper.toDepositDto(d);
@@ -172,7 +173,7 @@ public class SavingsDepositService {
     @Transactional(readOnly = true)
     public List<SavingsTransactionDto> listDepositTransactions(Long depositId) {
         SavingsDeposit d = depositRepo.findById(depositId)
-                .orElseThrow(() -> new IllegalArgumentException("Depozit ne postoji"));
+                .orElseThrow(() -> new SavingsDepositNotFoundException(depositId));
         UserContext me = userResolver.resolveCurrent();
         verifyDepositAccess(d, me);
         return txRepo.findByDepositIdOrderByCreatedAtDesc(depositId)
@@ -182,7 +183,7 @@ public class SavingsDepositService {
     @Transactional
     public SavingsDepositDto toggleAutoRenew(Long depositId, ToggleAutoRenewDto dto) {
         SavingsDeposit d = depositRepo.findById(depositId)
-                .orElseThrow(() -> new IllegalArgumentException("Depozit ne postoji"));
+                .orElseThrow(() -> new SavingsDepositNotFoundException(depositId));
         UserContext me = userResolver.resolveCurrent();
         verifyOwnership(d, me);
         if (d.getStatus() != SavingsDepositStatus.ACTIVE) {
@@ -195,7 +196,7 @@ public class SavingsDepositService {
     @Transactional
     public SavingsDepositDto withdrawEarly(Long depositId, WithdrawEarlyDto dto) {
         SavingsDeposit d = depositRepo.findById(depositId)
-                .orElseThrow(() -> new IllegalArgumentException("Depozit ne postoji"));
+                .orElseThrow(() -> new SavingsDepositNotFoundException(depositId));
         UserContext me = userResolver.resolveCurrent();
         verifyOwnership(d, me);
         if (d.getStatus() != SavingsDepositStatus.ACTIVE) {

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/service/SavingsDepositService.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/service/SavingsDepositService.java
@@ -1,0 +1,271 @@
+package rs.raf.banka2_bek.savings.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import rs.raf.banka2_bek.account.model.Account;
+import rs.raf.banka2_bek.account.model.AccountStatus;
+import rs.raf.banka2_bek.account.repository.AccountRepository;
+import rs.raf.banka2_bek.auth.util.UserContext;
+import rs.raf.banka2_bek.auth.util.UserResolver;
+import rs.raf.banka2_bek.otp.service.OtpService;
+import rs.raf.banka2_bek.savings.dto.OpenDepositDto;
+import rs.raf.banka2_bek.savings.dto.SavingsDepositDto;
+import rs.raf.banka2_bek.savings.dto.SavingsTransactionDto;
+import rs.raf.banka2_bek.savings.dto.ToggleAutoRenewDto;
+import rs.raf.banka2_bek.savings.dto.WithdrawEarlyDto;
+import rs.raf.banka2_bek.savings.entity.SavingsDeposit;
+import rs.raf.banka2_bek.savings.entity.SavingsDepositStatus;
+import rs.raf.banka2_bek.savings.entity.SavingsInterestRate;
+import rs.raf.banka2_bek.savings.entity.SavingsTransaction;
+import rs.raf.banka2_bek.savings.entity.SavingsTransactionType;
+import rs.raf.banka2_bek.savings.mapper.SavingsMapper;
+import rs.raf.banka2_bek.savings.repository.SavingsDepositRepository;
+import rs.raf.banka2_bek.savings.repository.SavingsTransactionRepository;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SavingsDepositService {
+
+    private static final Set<Integer> VALID_TERMS = Set.of(3, 6, 12, 24, 36);
+
+    private static final Map<String, BigDecimal> MIN_DEPOSIT = Map.of(
+            "RSD", new BigDecimal("10000"),
+            "JPY", new BigDecimal("10000"),
+            "EUR", new BigDecimal("100"),
+            "USD", new BigDecimal("100"),
+            "CHF", new BigDecimal("100"),
+            "GBP", new BigDecimal("100"),
+            "CAD", new BigDecimal("100"),
+            "AUD", new BigDecimal("100")
+    );
+
+    private final SavingsDepositRepository depositRepo;
+    private final SavingsTransactionRepository txRepo;
+    private final SavingsInterestRateService rateService;
+    private final SavingsMapper mapper;
+    private final AccountRepository accountRepo;
+    private final UserResolver userResolver;
+    private final OtpService otpService;
+
+    @Value("${bank.registration-number}")
+    private String bankRegistrationNumber;
+
+    @Transactional
+    public SavingsDepositDto openDeposit(OpenDepositDto dto) {
+        UserContext me = userResolver.resolveCurrent();
+        if (!me.isClient()) {
+            throw new AccessDeniedException("Samo klijenti mogu otvarati orocene depozite.");
+        }
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+
+        Map<String, Object> otpResult = otpService.verify(email, dto.getOtpCode());
+        if (!Boolean.TRUE.equals(otpResult.get("verified"))) {
+            throw new AccessDeniedException("OTP verifikacija nije uspela.");
+        }
+
+        if (!VALID_TERMS.contains(dto.getTermMonths())) {
+            throw new IllegalArgumentException("Rok mora biti jedan od: 3, 6, 12, 24, 36 meseci");
+        }
+
+        Account source = accountRepo.findById(dto.getSourceAccountId())
+                .orElseThrow(() -> new IllegalArgumentException("Izvorni racun ne postoji"));
+        verifyAccountOwnership(source, me.userId());
+        if (source.getStatus() != AccountStatus.ACTIVE) {
+            throw new IllegalArgumentException("Izvorni racun nije aktivan");
+        }
+
+        Account linked = accountRepo.findById(dto.getLinkedAccountId())
+                .orElseThrow(() -> new IllegalArgumentException("Povezani racun ne postoji"));
+        verifyAccountOwnership(linked, me.userId());
+        if (linked.getStatus() != AccountStatus.ACTIVE) {
+            throw new IllegalArgumentException("Povezani racun nije aktivan");
+        }
+
+        if (!source.getCurrency().getId().equals(linked.getCurrency().getId())) {
+            throw new IllegalArgumentException("Izvorni i povezani racun moraju biti u istoj valuti");
+        }
+
+        String currencyCode = source.getCurrency().getCode();
+        BigDecimal min = MIN_DEPOSIT.getOrDefault(currencyCode, new BigDecimal("100"));
+        if (dto.getPrincipalAmount().compareTo(min) < 0) {
+            throw new IllegalArgumentException(
+                "Minimalan iznos depozita u " + currencyCode + " je " + min);
+        }
+
+        SavingsInterestRate rate = rateService.findActive(source.getCurrency().getId(), dto.getTermMonths())
+                .orElseThrow(() -> new IllegalArgumentException(
+                    "Kamatna stopa nije dostupna za " + currencyCode + " rok " + dto.getTermMonths() + " meseci"));
+
+        if (source.getAvailableBalance().compareTo(dto.getPrincipalAmount()) < 0) {
+            throw new IllegalArgumentException(
+                "Nedovoljno raspolozivih sredstava na racunu " + source.getAccountNumber());
+        }
+
+        source.setBalance(source.getBalance().subtract(dto.getPrincipalAmount()));
+        source.setAvailableBalance(source.getAvailableBalance().subtract(dto.getPrincipalAmount()));
+        accountRepo.save(source);
+
+        LocalDate today = LocalDate.now(ZoneOffset.UTC);
+        LocalDate maturity = today.plusMonths(dto.getTermMonths());
+        LocalDate firstInterest = today.plusMonths(1);
+
+        SavingsDeposit deposit = SavingsDeposit.builder()
+                .clientId(me.userId())
+                .linkedAccountId(linked.getId())
+                .principalAmount(dto.getPrincipalAmount())
+                .currency(source.getCurrency())
+                .termMonths(dto.getTermMonths())
+                .annualInterestRate(rate.getAnnualRate())
+                .startDate(today)
+                .maturityDate(maturity)
+                .nextInterestPaymentDate(firstInterest)
+                .totalInterestPaid(BigDecimal.ZERO)
+                .autoRenew(dto.getAutoRenew())
+                .status(SavingsDepositStatus.ACTIVE)
+                .build();
+        deposit = depositRepo.save(deposit);
+
+        txRepo.save(SavingsTransaction.builder()
+                .deposit(deposit)
+                .type(SavingsTransactionType.OPEN)
+                .amount(dto.getPrincipalAmount())
+                .currency(source.getCurrency())
+                .processedDate(today)
+                .description("Otvaranje depozita rok=" + dto.getTermMonths() + "m stopa=" + rate.getAnnualRate() + "% p.a.")
+                .build());
+
+        log.info("Otvoren stedni depozit id={} client={} principal={} {} term={}m",
+                deposit.getId(), me.userId(), dto.getPrincipalAmount(), currencyCode, dto.getTermMonths());
+
+        return mapper.toDepositDto(deposit);
+    }
+
+    @Transactional(readOnly = true)
+    public List<SavingsDepositDto> listMyDeposits() {
+        UserContext me = userResolver.resolveCurrent();
+        return depositRepo.findByClientIdOrderByCreatedAtDesc(me.userId())
+                .stream().map(mapper::toDepositDto).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public SavingsDepositDto getDeposit(Long id) {
+        SavingsDeposit d = depositRepo.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Depozit ne postoji"));
+        UserContext me = userResolver.resolveCurrent();
+        verifyDepositAccess(d, me);
+        return mapper.toDepositDto(d);
+    }
+
+    @Transactional(readOnly = true)
+    public List<SavingsTransactionDto> listDepositTransactions(Long depositId) {
+        SavingsDeposit d = depositRepo.findById(depositId)
+                .orElseThrow(() -> new IllegalArgumentException("Depozit ne postoji"));
+        UserContext me = userResolver.resolveCurrent();
+        verifyDepositAccess(d, me);
+        return txRepo.findByDepositIdOrderByCreatedAtDesc(depositId)
+                .stream().map(mapper::toTransactionDto).toList();
+    }
+
+    @Transactional
+    public SavingsDepositDto toggleAutoRenew(Long depositId, ToggleAutoRenewDto dto) {
+        SavingsDeposit d = depositRepo.findById(depositId)
+                .orElseThrow(() -> new IllegalArgumentException("Depozit ne postoji"));
+        UserContext me = userResolver.resolveCurrent();
+        verifyOwnership(d, me);
+        if (d.getStatus() != SavingsDepositStatus.ACTIVE) {
+            throw new IllegalArgumentException("Auto-obnova se moze menjati samo na aktivnim depozitima");
+        }
+        d.setAutoRenew(dto.getAutoRenew());
+        return mapper.toDepositDto(depositRepo.save(d));
+    }
+
+    @Transactional
+    public SavingsDepositDto withdrawEarly(Long depositId, WithdrawEarlyDto dto) {
+        SavingsDeposit d = depositRepo.findById(depositId)
+                .orElseThrow(() -> new IllegalArgumentException("Depozit ne postoji"));
+        UserContext me = userResolver.resolveCurrent();
+        verifyOwnership(d, me);
+        if (d.getStatus() != SavingsDepositStatus.ACTIVE) {
+            throw new IllegalArgumentException("Depozit nije aktivan");
+        }
+
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        Map<String, Object> otpResult = otpService.verify(email, dto.getOtpCode());
+        if (!Boolean.TRUE.equals(otpResult.get("verified"))) {
+            throw new AccessDeniedException("OTP verifikacija nije uspela.");
+        }
+
+        BigDecimal penalty = SavingsCalculator.earlyWithdrawalPenalty(d.getPrincipalAmount());
+        BigDecimal returned = d.getPrincipalAmount().subtract(penalty);
+
+        Account linked = accountRepo.findForUpdateById(d.getLinkedAccountId())
+                .orElseThrow(() -> new IllegalArgumentException("Povezani racun ne postoji"));
+        creditAccount(linked, returned);
+
+        Account bankAccount = accountRepo.findBankAccountByCurrencyId(
+                bankRegistrationNumber, d.getCurrency().getId())
+                .orElseThrow(() -> new IllegalStateException(
+                    "Banka nema racun u valuti " + d.getCurrency().getCode()));
+        creditAccount(bankAccount, penalty);
+
+        d.setStatus(SavingsDepositStatus.WITHDRAWN_EARLY);
+        depositRepo.save(d);
+
+        LocalDate today = LocalDate.now(ZoneOffset.UTC);
+        txRepo.save(SavingsTransaction.builder()
+                .deposit(d).type(SavingsTransactionType.EARLY_WITHDRAWAL_PRINCIPAL)
+                .amount(returned).currency(d.getCurrency()).processedDate(today)
+                .description("Raskid pre dospeca - glavnica umanjena za 1% penal")
+                .build());
+        txRepo.save(SavingsTransaction.builder()
+                .deposit(d).type(SavingsTransactionType.EARLY_WITHDRAWAL_PENALTY)
+                .amount(penalty).currency(d.getCurrency()).processedDate(today)
+                .description("Penal 1% glavnice")
+                .build());
+
+        log.info("Raskinut depozit id={} client={} penalty={}",
+                d.getId(), me.userId(), penalty);
+
+        return mapper.toDepositDto(d);
+    }
+
+    private void verifyAccountOwnership(Account account, Long clientId) {
+        if (account.getClient() == null || !account.getClient().getId().equals(clientId)) {
+            throw new AccessDeniedException("Racun " + account.getAccountNumber() + " ne pripada korisniku.");
+        }
+    }
+
+    private void verifyOwnership(SavingsDeposit d, UserContext me) {
+        if (!me.isClient() || !d.getClientId().equals(me.userId())) {
+            throw new AccessDeniedException("Depozit ne pripada korisniku.");
+        }
+    }
+
+    private void verifyDepositAccess(SavingsDeposit d, UserContext me) {
+        if (me.isEmployee()) {
+            throw new AccessDeniedException("Zaposleni koriste /admin/savings/* rute.");
+        }
+        if (me.isClient() && !d.getClientId().equals(me.userId())) {
+            throw new AccessDeniedException("Depozit ne pripada korisniku.");
+        }
+    }
+
+    private void creditAccount(Account account, BigDecimal amount) {
+        account.setBalance(account.getBalance().add(amount));
+        account.setAvailableBalance(account.getAvailableBalance().add(amount));
+        accountRepo.save(account);
+    }
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/service/SavingsInterestRateService.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/service/SavingsInterestRateService.java
@@ -1,0 +1,63 @@
+package rs.raf.banka2_bek.savings.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import rs.raf.banka2_bek.currency.model.Currency;
+import rs.raf.banka2_bek.currency.repository.CurrencyRepository;
+import rs.raf.banka2_bek.savings.dto.SavingsRateDto;
+import rs.raf.banka2_bek.savings.dto.UpsertSavingsRateDto;
+import rs.raf.banka2_bek.savings.entity.SavingsInterestRate;
+import rs.raf.banka2_bek.savings.mapper.SavingsMapper;
+import rs.raf.banka2_bek.savings.repository.SavingsInterestRateRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class SavingsInterestRateService {
+
+    private final SavingsInterestRateRepository rateRepo;
+    private final CurrencyRepository currencyRepo;
+    private final SavingsMapper mapper;
+
+    @Transactional(readOnly = true)
+    public Optional<SavingsInterestRate> findActive(Long currencyId, Integer termMonths) {
+        return rateRepo.findActive(currencyId, termMonths);
+    }
+
+    @Transactional(readOnly = true)
+    public List<SavingsRateDto> listActive(String currencyCode) {
+        List<SavingsInterestRate> rates = currencyCode != null && !currencyCode.isBlank()
+                ? rateRepo.findActiveByCurrencyCode(currencyCode.toUpperCase())
+                : rateRepo.findAllActive();
+        return rates.stream().map(mapper::toRateDto).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<SavingsRateDto> listAll() {
+        return rateRepo.findAll().stream().map(mapper::toRateDto).toList();
+    }
+
+    @Transactional
+    public SavingsRateDto upsert(UpsertSavingsRateDto dto) {
+        Currency currency = currencyRepo.findByCode(dto.getCurrencyCode().toUpperCase())
+                .orElseThrow(() -> new IllegalArgumentException("Valuta ne postoji: " + dto.getCurrencyCode()));
+
+        rateRepo.findActive(currency.getId(), dto.getTermMonths()).ifPresent(existing -> {
+            existing.setActive(false);
+            rateRepo.save(existing);
+        });
+
+        SavingsInterestRate newRate = SavingsInterestRate.builder()
+                .currency(currency)
+                .termMonths(dto.getTermMonths())
+                .annualRate(dto.getAnnualRate())
+                .active(true)
+                .effectiveFrom(LocalDate.now())
+                .build();
+        return mapper.toRateDto(rateRepo.save(newRate));
+    }
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/service/SavingsScheduler.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/service/SavingsScheduler.java
@@ -8,31 +8,27 @@ import org.springframework.context.event.EventListener;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import rs.raf.banka2_bek.account.model.Account;
-import rs.raf.banka2_bek.account.repository.AccountRepository;
 import rs.raf.banka2_bek.savings.entity.SavingsDeposit;
 import rs.raf.banka2_bek.savings.entity.SavingsDepositStatus;
-import rs.raf.banka2_bek.savings.entity.SavingsInterestRate;
-import rs.raf.banka2_bek.savings.entity.SavingsTransaction;
-import rs.raf.banka2_bek.savings.entity.SavingsTransactionType;
 import rs.raf.banka2_bek.savings.repository.SavingsDepositRepository;
-import rs.raf.banka2_bek.savings.repository.SavingsTransactionRepository;
 
-import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.util.List;
 
+/**
+ * CRON + startup ulaz tacka za stedne deposit-e. Sve transakcione operacije
+ * delegira na {@link SavingsDepositProcessor} (drugi bean) tako da @Transactional
+ * prolazi kroz Spring AOP proxy. Intra-class @Transactional pozivi bi bili
+ * silently ignorisani (CGLib proxy ne presreca direktne `this.method()` pozive).
+ */
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class SavingsScheduler {
 
     private final SavingsDepositRepository depositRepo;
-    private final SavingsTransactionRepository txRepo;
-    private final SavingsInterestRateService rateService;
-    private final AccountRepository accountRepo;
+    private final SavingsDepositProcessor processor;
 
     @Scheduled(cron = "0 0 2 * * *")
     public void processSavingsDeposits() {
@@ -53,7 +49,7 @@ public class SavingsScheduler {
         log.info("SavingsScheduler: {} deposit-a za isplatu kamate za {}", dueForInterest.size(), today);
         for (SavingsDeposit d : dueForInterest) {
             try {
-                payMonthlyInterest(d, today);
+                processor.payMonthlyInterest(d, today);
             } catch (ObjectOptimisticLockingFailureException | OptimisticLockException oole) {
                 log.debug("Scheduler: skipped deposit {} (locked by another worker)", d.getId());
             } catch (Exception e) {
@@ -67,9 +63,9 @@ public class SavingsScheduler {
         for (SavingsDeposit d : matured) {
             try {
                 if (Boolean.TRUE.equals(d.getAutoRenew())) {
-                    renewDeposit(d, today);
+                    processor.renewDeposit(d, today);
                 } else {
-                    returnPrincipal(d, today);
+                    processor.returnPrincipal(d, today);
                 }
             } catch (ObjectOptimisticLockingFailureException | OptimisticLockException oole) {
                 log.debug("Scheduler: skipped maturity {} (locked)", d.getId());
@@ -77,87 +73,5 @@ public class SavingsScheduler {
                 log.error("Scheduler: failed maturity for deposit {}: {}", d.getId(), e.getMessage(), e);
             }
         }
-    }
-
-    @Transactional
-    public void payMonthlyInterest(SavingsDeposit d, LocalDate today) {
-        BigDecimal monthlyInterest = SavingsCalculator.monthlyInterest(
-                d.getPrincipalAmount(), d.getAnnualInterestRate());
-
-        Account linked = accountRepo.findForUpdateById(d.getLinkedAccountId())
-                .orElseThrow(() -> new IllegalStateException("Povezani racun ne postoji"));
-        linked.setBalance(linked.getBalance().add(monthlyInterest));
-        linked.setAvailableBalance(linked.getAvailableBalance().add(monthlyInterest));
-        accountRepo.save(linked);
-
-        d.setTotalInterestPaid(d.getTotalInterestPaid().add(monthlyInterest));
-        d.setNextInterestPaymentDate(SavingsCalculator.nextMonthlyAnniversary(d.getNextInterestPaymentDate()));
-        depositRepo.save(d);
-
-        txRepo.save(SavingsTransaction.builder()
-                .deposit(d).type(SavingsTransactionType.INTEREST_PAYMENT)
-                .amount(monthlyInterest).currency(d.getCurrency()).processedDate(today)
-                .description("Mesecna kamata depozita #" + d.getId())
-                .build());
-
-        log.info("Scheduler: isplacena kamata {} {} za deposit {}",
-                monthlyInterest, d.getCurrency().getCode(), d.getId());
-    }
-
-    @Transactional
-    public void returnPrincipal(SavingsDeposit d, LocalDate today) {
-        Account linked = accountRepo.findForUpdateById(d.getLinkedAccountId())
-                .orElseThrow(() -> new IllegalStateException("Povezani racun ne postoji"));
-        linked.setBalance(linked.getBalance().add(d.getPrincipalAmount()));
-        linked.setAvailableBalance(linked.getAvailableBalance().add(d.getPrincipalAmount()));
-        accountRepo.save(linked);
-
-        d.setStatus(SavingsDepositStatus.MATURED);
-        depositRepo.save(d);
-
-        txRepo.save(SavingsTransaction.builder()
-                .deposit(d).type(SavingsTransactionType.PRINCIPAL_RETURN)
-                .amount(d.getPrincipalAmount()).currency(d.getCurrency()).processedDate(today)
-                .description("Glavnica dospelog depozita #" + d.getId())
-                .build());
-
-        log.info("Scheduler: vracena glavnica {} {} za deposit {}",
-                d.getPrincipalAmount(), d.getCurrency().getCode(), d.getId());
-    }
-
-    @Transactional
-    public void renewDeposit(SavingsDeposit d, LocalDate today) {
-        BigDecimal currentRate = rateService.findActive(d.getCurrency().getId(), d.getTermMonths())
-                .map(SavingsInterestRate::getAnnualRate)
-                .orElseThrow(() -> new IllegalStateException(
-                    "Stopa za auto-obnovu nije dostupna za " + d.getCurrency().getCode()));
-
-        d.setStatus(SavingsDepositStatus.RENEWED);
-        depositRepo.save(d);
-
-        SavingsDeposit renewed = SavingsDeposit.builder()
-                .clientId(d.getClientId())
-                .linkedAccountId(d.getLinkedAccountId())
-                .principalAmount(d.getPrincipalAmount())
-                .currency(d.getCurrency())
-                .termMonths(d.getTermMonths())
-                .annualInterestRate(currentRate)
-                .startDate(today)
-                .maturityDate(today.plusMonths(d.getTermMonths()))
-                .nextInterestPaymentDate(today.plusMonths(1))
-                .totalInterestPaid(BigDecimal.ZERO)
-                .autoRenew(true)
-                .status(SavingsDepositStatus.ACTIVE)
-                .build();
-        renewed = depositRepo.save(renewed);
-
-        txRepo.save(SavingsTransaction.builder()
-                .deposit(renewed).type(SavingsTransactionType.RENEWAL_OPEN)
-                .amount(d.getPrincipalAmount()).currency(d.getCurrency()).processedDate(today)
-                .description("Auto-obnova dospelog depozita #" + d.getId())
-                .build());
-
-        log.info("Scheduler: auto-obnova {} -> {} za client {}",
-                d.getId(), renewed.getId(), d.getClientId());
     }
 }

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/service/SavingsScheduler.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/savings/service/SavingsScheduler.java
@@ -1,0 +1,163 @@
+package rs.raf.banka2_bek.savings.service;
+
+import jakarta.persistence.OptimisticLockException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import rs.raf.banka2_bek.account.model.Account;
+import rs.raf.banka2_bek.account.repository.AccountRepository;
+import rs.raf.banka2_bek.savings.entity.SavingsDeposit;
+import rs.raf.banka2_bek.savings.entity.SavingsDepositStatus;
+import rs.raf.banka2_bek.savings.entity.SavingsInterestRate;
+import rs.raf.banka2_bek.savings.entity.SavingsTransaction;
+import rs.raf.banka2_bek.savings.entity.SavingsTransactionType;
+import rs.raf.banka2_bek.savings.repository.SavingsDepositRepository;
+import rs.raf.banka2_bek.savings.repository.SavingsTransactionRepository;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SavingsScheduler {
+
+    private final SavingsDepositRepository depositRepo;
+    private final SavingsTransactionRepository txRepo;
+    private final SavingsInterestRateService rateService;
+    private final AccountRepository accountRepo;
+
+    @Scheduled(cron = "0 0 2 * * *")
+    public void processSavingsDeposits() {
+        runSavingsCycle();
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void onStartup() {
+        log.info("SavingsScheduler: startup catch-up run");
+        runSavingsCycle();
+    }
+
+    public void runSavingsCycle() {
+        LocalDate today = LocalDate.now(ZoneOffset.UTC);
+
+        List<SavingsDeposit> dueForInterest = depositRepo.findByStatusAndNextInterestPaymentDateLessThanEqual(
+                SavingsDepositStatus.ACTIVE, today);
+        log.info("SavingsScheduler: {} deposit-a za isplatu kamate za {}", dueForInterest.size(), today);
+        for (SavingsDeposit d : dueForInterest) {
+            try {
+                payMonthlyInterest(d, today);
+            } catch (ObjectOptimisticLockingFailureException | OptimisticLockException oole) {
+                log.debug("Scheduler: skipped deposit {} (locked by another worker)", d.getId());
+            } catch (Exception e) {
+                log.error("Scheduler: failed interest for deposit {}: {}", d.getId(), e.getMessage(), e);
+            }
+        }
+
+        List<SavingsDeposit> matured = depositRepo.findByStatusAndMaturityDateLessThanEqual(
+                SavingsDepositStatus.ACTIVE, today);
+        log.info("SavingsScheduler: {} deposit-a za dospece za {}", matured.size(), today);
+        for (SavingsDeposit d : matured) {
+            try {
+                if (Boolean.TRUE.equals(d.getAutoRenew())) {
+                    renewDeposit(d, today);
+                } else {
+                    returnPrincipal(d, today);
+                }
+            } catch (ObjectOptimisticLockingFailureException | OptimisticLockException oole) {
+                log.debug("Scheduler: skipped maturity {} (locked)", d.getId());
+            } catch (Exception e) {
+                log.error("Scheduler: failed maturity for deposit {}: {}", d.getId(), e.getMessage(), e);
+            }
+        }
+    }
+
+    @Transactional
+    public void payMonthlyInterest(SavingsDeposit d, LocalDate today) {
+        BigDecimal monthlyInterest = SavingsCalculator.monthlyInterest(
+                d.getPrincipalAmount(), d.getAnnualInterestRate());
+
+        Account linked = accountRepo.findForUpdateById(d.getLinkedAccountId())
+                .orElseThrow(() -> new IllegalStateException("Povezani racun ne postoji"));
+        linked.setBalance(linked.getBalance().add(monthlyInterest));
+        linked.setAvailableBalance(linked.getAvailableBalance().add(monthlyInterest));
+        accountRepo.save(linked);
+
+        d.setTotalInterestPaid(d.getTotalInterestPaid().add(monthlyInterest));
+        d.setNextInterestPaymentDate(SavingsCalculator.nextMonthlyAnniversary(d.getNextInterestPaymentDate()));
+        depositRepo.save(d);
+
+        txRepo.save(SavingsTransaction.builder()
+                .deposit(d).type(SavingsTransactionType.INTEREST_PAYMENT)
+                .amount(monthlyInterest).currency(d.getCurrency()).processedDate(today)
+                .description("Mesecna kamata depozita #" + d.getId())
+                .build());
+
+        log.info("Scheduler: isplacena kamata {} {} za deposit {}",
+                monthlyInterest, d.getCurrency().getCode(), d.getId());
+    }
+
+    @Transactional
+    public void returnPrincipal(SavingsDeposit d, LocalDate today) {
+        Account linked = accountRepo.findForUpdateById(d.getLinkedAccountId())
+                .orElseThrow(() -> new IllegalStateException("Povezani racun ne postoji"));
+        linked.setBalance(linked.getBalance().add(d.getPrincipalAmount()));
+        linked.setAvailableBalance(linked.getAvailableBalance().add(d.getPrincipalAmount()));
+        accountRepo.save(linked);
+
+        d.setStatus(SavingsDepositStatus.MATURED);
+        depositRepo.save(d);
+
+        txRepo.save(SavingsTransaction.builder()
+                .deposit(d).type(SavingsTransactionType.PRINCIPAL_RETURN)
+                .amount(d.getPrincipalAmount()).currency(d.getCurrency()).processedDate(today)
+                .description("Glavnica dospelog depozita #" + d.getId())
+                .build());
+
+        log.info("Scheduler: vracena glavnica {} {} za deposit {}",
+                d.getPrincipalAmount(), d.getCurrency().getCode(), d.getId());
+    }
+
+    @Transactional
+    public void renewDeposit(SavingsDeposit d, LocalDate today) {
+        BigDecimal currentRate = rateService.findActive(d.getCurrency().getId(), d.getTermMonths())
+                .map(SavingsInterestRate::getAnnualRate)
+                .orElseThrow(() -> new IllegalStateException(
+                    "Stopa za auto-obnovu nije dostupna za " + d.getCurrency().getCode()));
+
+        d.setStatus(SavingsDepositStatus.RENEWED);
+        depositRepo.save(d);
+
+        SavingsDeposit renewed = SavingsDeposit.builder()
+                .clientId(d.getClientId())
+                .linkedAccountId(d.getLinkedAccountId())
+                .principalAmount(d.getPrincipalAmount())
+                .currency(d.getCurrency())
+                .termMonths(d.getTermMonths())
+                .annualInterestRate(currentRate)
+                .startDate(today)
+                .maturityDate(today.plusMonths(d.getTermMonths()))
+                .nextInterestPaymentDate(today.plusMonths(1))
+                .totalInterestPaid(BigDecimal.ZERO)
+                .autoRenew(true)
+                .status(SavingsDepositStatus.ACTIVE)
+                .build();
+        renewed = depositRepo.save(renewed);
+
+        txRepo.save(SavingsTransaction.builder()
+                .deposit(renewed).type(SavingsTransactionType.RENEWAL_OPEN)
+                .amount(d.getPrincipalAmount()).currency(d.getCurrency()).processedDate(today)
+                .description("Auto-obnova dospelog depozita #" + d.getId())
+                .build());
+
+        log.info("Scheduler: auto-obnova {} -> {} za client {}",
+                d.getId(), renewed.getId(), d.getClientId());
+    }
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/tax/service/TaxService.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/tax/service/TaxService.java
@@ -233,12 +233,19 @@ public class TaxService {
             // Za svaki listing: profit = sell - buy, konvertuj u RSD, akumuliraj.
             // NET dobit/gubitak se racuna preko svih listinga; porez je 0 ako je total <= 0.
             // P2.4 — biljezimo per-listing breakdown za prikaz/audit.
+            //
+            // Spec §517 + bug prijavljen 12.05.2026 (tim screenshot tax_record_breakdowns):
+            // pre fix-a, listings sa SAMO buy (bez sell) su davali profit = 0 - buy = -buy
+            // sto je laznja indikacija "gubitka" — porez se po spec-u racuna SAMO na
+            // REALIZOVANU dobit (kad je prodaja izvrsena). Skupljac SVIH bought listings
+            // u breakdown-u je davao haosno "sve negativno" stanje. Sad ukljucujemo
+            // samo listings sa sell > 0 (realizovani trgovni dogadjaj). Sva nepotrosenih
+            // pozicija ostaju u portfolio-u kao unrealized — bez tax efekta.
             BigDecimal totalProfit = BigDecimal.ZERO;
-            Set<Long> allListings = new HashSet<>(buyByListing.keySet());
-            allListings.addAll(sellByListing.keySet());
+            Set<Long> realizedListings = new HashSet<>(sellByListing.keySet());
             // Akumuliraj per-listing breakdown stavke pre nego sto saznamo TaxRecord ID-jeve
             java.util.List<PerListingProfit> perListingProfits = new java.util.ArrayList<>();
-            for (Long listingId : allListings) {
+            for (Long listingId : realizedListings) {
                 BigDecimal sell = sellByListing.getOrDefault(listingId, BigDecimal.ZERO);
                 BigDecimal buy = buyByListing.getOrDefault(listingId, BigDecimal.ZERO);
                 BigDecimal assetProfit = sell.subtract(buy);

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/auth/service/AccountLockoutServiceTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/auth/service/AccountLockoutServiceTest.java
@@ -39,12 +39,20 @@ class AccountLockoutServiceTest {
     }
 
     @Test
-    @DisplayName("Posle 5 neuspeha — racun je lock-ovan")
+    @DisplayName("Posle 5 neuspeha — racun je lock-ovan i 5. recordFailure baca AccountLockedException")
     void fiveFailures_locksAccount() {
+        // Spec Sc 5 (Bug T1-015 12.05.2026): 5. neuspesni pokusaj sam baca
+        // AccountLockedException — korisnik vidi lockout poruku na 5. pokusaju,
+        // ne tek na 6. Prvih 4 pokusaja su tihi.
         String email = "alice@example.com";
-        for (int i = 0; i < 5; i++) {
+        for (int i = 0; i < 4; i++) {
             service.recordFailure(email);
         }
+        assertThat(service.isLocked(email)).isFalse();
+
+        assertThatThrownBy(() -> service.recordFailure(email))
+                .isInstanceOf(AccountLockoutService.AccountLockedException.class)
+                .hasMessageContaining("Nalog je privremeno zakljucan");
 
         assertThat(service.isLocked(email)).isTrue();
     }
@@ -77,13 +85,19 @@ class AccountLockoutServiceTest {
     @DisplayName("assertNotLocked baca AccountLockedException kad je lock aktivan")
     void assertNotLocked_throwsWhenLocked() {
         String email = "alice@example.com";
-        for (int i = 0; i < 5; i++) {
+        // Prvih 4 ne bacaju; 5. baca i postavlja lock. Hvatamo da nastavimo.
+        for (int i = 0; i < 4; i++) {
             service.recordFailure(email);
+        }
+        try {
+            service.recordFailure(email);
+        } catch (AccountLockoutService.AccountLockedException expected) {
+            // ocekivano
         }
 
         assertThatThrownBy(() -> service.assertNotLocked(email))
                 .isInstanceOf(AccountLockoutService.AccountLockedException.class)
-                .hasMessageContaining("locked");
+                .hasMessageContaining("Nalog je privremeno zakljucan");
     }
 
     @Test
@@ -105,7 +119,13 @@ class AccountLockoutServiceTest {
     @Test
     @DisplayName("Razliciti email-ovi se nezavisno broje")
     void differentEmails_independent() {
-        for (int i = 0; i < 5; i++) service.recordFailure("alice@example.com");
+        // 5. neuspeh za alice baca exception — hvatamo da bismo nastavili sa bob.
+        for (int i = 0; i < 4; i++) service.recordFailure("alice@example.com");
+        try {
+            service.recordFailure("alice@example.com");
+        } catch (AccountLockoutService.AccountLockedException expected) {
+            // ok
+        }
         service.recordFailure("bob@example.com");
 
         assertThat(service.isLocked("alice@example.com")).isTrue();

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/auth/service/AuthServiceTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/auth/service/AuthServiceTest.java
@@ -192,7 +192,7 @@ class AuthServiceTest {
 
         assertThatThrownBy(() -> authService.login(new LoginRequestDto("missing@test.com", "bad")))
                 .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("Invalid email or password");
+                .hasMessageContaining("Neispravan email ili lozinka");
     }
 
     // ===== Employee login with salt-based password hashing =====
@@ -223,7 +223,7 @@ class AuthServiceTest {
 
         assertThatThrownBy(() -> authService.login(new LoginRequestDto(employee.getEmail(), "wrongPass")))
                 .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("Invalid email or password");
+                .hasMessageContaining("Neispravan email ili lozinka");
     }
 
     // ===== Login with inactive account =====
@@ -253,7 +253,7 @@ class AuthServiceTest {
 
         assertThatThrownBy(() -> authService.login(new LoginRequestDto("inactive-emp@test.com", "password")))
                 .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("Employee account is not active");
+                .hasMessageContaining("Nalog je deaktiviran");
     }
 
     @Test
@@ -271,7 +271,7 @@ class AuthServiceTest {
 
         assertThatThrownBy(() -> authService.login(new LoginRequestDto("inactive@test.com", "password")))
                 .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("User account is not active");
+                .hasMessageContaining("Nalog je deaktiviran");
     }
 
     // ===== Password reset token expiry validation =====
@@ -506,6 +506,6 @@ class AuthServiceTest {
 
         assertThatThrownBy(() -> authService.login(new LoginRequestDto("null-active@test.com", "pass")))
                 .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("Employee account is not active");
+                .hasMessageContaining("Nalog je deaktiviran");
     }
 }

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/employee/service/EmployeeServiceImplExtendedTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/employee/service/EmployeeServiceImplExtendedTest.java
@@ -92,11 +92,15 @@ class EmployeeServiceImplExtendedTest {
     }
 
     @Test void update_ok() {
+        // Spec §30 + Bug T1-010 (12.05.2026): email se NE moze menjati. Test sad
+        // proverava update sa istim email-om (idempotent) + drugim ne-email
+        // poljem (firstName).
         Employee e = emp(1L, true, Set.of("READ"));
         when(employeeRepository.findById(1L)).thenReturn(Optional.of(e));
-        when(employeeRepository.existsByEmailAndIdNot("n@b.rs", 1L)).thenReturn(false);
         when(employeeRepository.save(any())).thenAnswer(i -> i.getArgument(0));
-        UpdateEmployeeRequestDto req = new UpdateEmployeeRequestDto(); req.setFirstName("N"); req.setEmail("n@b.rs");
+        UpdateEmployeeRequestDto req = new UpdateEmployeeRequestDto();
+        req.setFirstName("N");
+        req.setEmail("m@b.rs"); // isti email kao postojeci → no-op
         assertThat(service.updateEmployee(1L, req).getFirstName()).isEqualTo("N");
     }
 
@@ -105,11 +109,14 @@ class EmployeeServiceImplExtendedTest {
         assertThatThrownBy(() -> service.updateEmployee(1L, new UpdateEmployeeRequestDto())).isInstanceOf(IllegalStateException.class);
     }
 
-    @Test void update_dupEmail_fails() {
+    @Test void update_emailChange_rejected() {
+        // Bug T1-010: pokusaj promene email-a vraca IllegalArgumentException sa
+        // jasnom porukom. Pre 12.05.2026 BE je propustao izmenu email-a.
         when(employeeRepository.findById(1L)).thenReturn(Optional.of(emp(1L, true, Set.of("READ"))));
-        when(employeeRepository.existsByEmailAndIdNot("d@b.rs", 1L)).thenReturn(true);
         UpdateEmployeeRequestDto req = new UpdateEmployeeRequestDto(); req.setEmail("d@b.rs");
-        assertThatThrownBy(() -> service.updateEmployee(1L, req)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> service.updateEmployee(1L, req))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Email zaposlenog se ne moze menjati");
     }
 
     @Test void deactivate_ok() {

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/employee/service/EmployeeServiceImplMoreTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/employee/service/EmployeeServiceImplMoreTest.java
@@ -133,13 +133,14 @@ class EmployeeServiceImplMoreTest {
 
     @Test
     void updateEmployeeUpdatesAllFields() {
+        // Spec §30 + Bug T1-010 (12.05.2026): email read-only. Test sad koristi
+        // isti email (idempotent — BE prihvata) i menja sva ostala polja.
         Employee e = buildEmployee(5L, "old@x.com", Set.of("VIEW_STOCKS"), true);
         when(employeeRepository.findById(5L)).thenReturn(Optional.of(e));
-        when(employeeRepository.existsByEmailAndIdNot("new@x.com", 5L)).thenReturn(false);
         when(employeeRepository.save(any(Employee.class))).thenAnswer(i -> i.getArgument(0));
 
         UpdateEmployeeRequestDto r = new UpdateEmployeeRequestDto();
-        r.setEmail("new@x.com");
+        r.setEmail("old@x.com"); // isti email — no-op
         r.setFirstName("NF"); r.setLastName("NL");
         r.setDateOfBirth(LocalDate.of(2000, 2, 2));
         r.setGender("F"); r.setPhone("+999"); r.setAddress("NewAddr");
@@ -149,7 +150,7 @@ class EmployeeServiceImplMoreTest {
 
         EmployeeResponseDto resp = employeeService.updateEmployee(5L, r);
 
-        assertThat(resp.getEmail()).isEqualTo("new@x.com");
+        assertThat(resp.getEmail()).isEqualTo("old@x.com");
         assertThat(resp.getFirstName()).isEqualTo("NF");
         assertThat(resp.getLastName()).isEqualTo("NL");
         assertThat(resp.getDateOfBirth()).isEqualTo(LocalDate.of(2000, 2, 2));
@@ -186,16 +187,17 @@ class EmployeeServiceImplMoreTest {
     }
 
     @Test
-    void updateEmployeeEmailWithoutConflictSucceeds() {
+    void updateEmployeeEmailChangeIsRejected() {
+        // Bug T1-010 (12.05.2026): pokusaj promene email-a na drugi vrednost
+        // se odbija sa IllegalArgumentException — email je identitet zaposlenog.
         Employee e = buildEmployee(7L, "a@a.com", Set.of("VIEW_STOCKS"), true);
         when(employeeRepository.findById(7L)).thenReturn(Optional.of(e));
-        when(employeeRepository.existsByEmailAndIdNot("b@b.com", 7L)).thenReturn(false);
-        when(employeeRepository.save(any(Employee.class))).thenAnswer(i -> i.getArgument(0));
 
         UpdateEmployeeRequestDto r = new UpdateEmployeeRequestDto();
-        r.setEmail("b@b.com");
-        EmployeeResponseDto resp = employeeService.updateEmployee(7L, r);
-        assertThat(resp.getEmail()).isEqualTo("b@b.com");
+        r.setEmail("b@b.com"); // razlicit email — odbija se
+        assertThatThrownBy(() -> employeeService.updateEmployee(7L, r))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Email zaposlenog se ne moze menjati");
     }
 
     @Test

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/employee/service/EmployeeServiceImplTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/employee/service/EmployeeServiceImplTest.java
@@ -122,22 +122,28 @@ class EmployeeServiceImplTest {
     }
 
     @Test
-    void updateEmployeeRejectsEmailConflict() {
+    void updateEmployeeRejectsEmailChange() {
+        // Bug T1-010 (12.05.2026): pre fix-a BE je dozvoljavao izmenu email-a
+        // i samo proveravao da li je email vec zauzet od drugog naloga (dup
+        // check). Sad email se NE moze menjati uopste (read-only po Plan_
+        // Manuelnog_Testiranja + security best practice — email je identitet
+        // naloga). Test sad proverava da pokusaj postavljanja drugacijeg
+        // email-a baca exception sa porukom o read-only ponasanju.
         Employee employee = Employee.builder()
                 .id(2L)
+                .email("original@test.com")
                 .permissions(Set.of("VIEW_STOCKS"))
                 .active(true)
                 .build();
 
         when(employeeRepository.findById(2L)).thenReturn(Optional.of(employee));
-        when(employeeRepository.existsByEmailAndIdNot("dup@test.com", 2L)).thenReturn(true);
 
         UpdateEmployeeRequestDto request = new UpdateEmployeeRequestDto();
         request.setEmail("dup@test.com");
 
         assertThatThrownBy(() -> employeeService.updateEmployee(2L, request))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("email");
+                .hasMessageContaining("Email zaposlenog se ne moze menjati");
     }
 
     @Test

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/savings/service/SavingsCalculatorTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/savings/service/SavingsCalculatorTest.java
@@ -1,0 +1,52 @@
+package rs.raf.banka2_bek.savings.service;
+
+import org.junit.jupiter.api.Test;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SavingsCalculatorTest {
+
+    @Test
+    void monthlyInterest_rsd_4percent_200k() {
+        BigDecimal result = SavingsCalculator.monthlyInterest(
+                new BigDecimal("200000"), new BigDecimal("4.00"));
+        // 200000 * 4.00 / 1200 = 666.6667
+        assertThat(result).isEqualByComparingTo("666.6667");
+    }
+
+    @Test
+    void monthlyInterest_eur_2percent_1000() {
+        BigDecimal result = SavingsCalculator.monthlyInterest(
+                new BigDecimal("1000"), new BigDecimal("2.00"));
+        // 1000 * 2.00 / 1200 = 1.6667
+        assertThat(result).isEqualByComparingTo("1.6667");
+    }
+
+    @Test
+    void totalInterestOverTerm_12months_4percent_200k() {
+        BigDecimal result = SavingsCalculator.totalInterestOverTerm(
+                new BigDecimal("200000"), new BigDecimal("4.00"), 12);
+        // 666.6667 * 12 = 8000.0004
+        assertThat(result).isEqualByComparingTo("8000.0004");
+    }
+
+    @Test
+    void earlyWithdrawalPenalty_1percent() {
+        BigDecimal result = SavingsCalculator.earlyWithdrawalPenalty(new BigDecimal("200000"));
+        // 200000 * 0.01 = 2000.0000
+        assertThat(result).isEqualByComparingTo("2000.0000");
+    }
+
+    @Test
+    void nextMonthlyAnniversary_endOfMonth31to28() {
+        LocalDate result = SavingsCalculator.nextMonthlyAnniversary(LocalDate.of(2026, 1, 31));
+        assertThat(result).isEqualTo(LocalDate.of(2026, 2, 28));
+    }
+
+    @Test
+    void nextMonthlyAnniversary_regularMonth() {
+        LocalDate result = SavingsCalculator.nextMonthlyAnniversary(LocalDate.of(2026, 5, 12));
+        assertThat(result).isEqualTo(LocalDate.of(2026, 6, 12));
+    }
+}

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/savings/service/SavingsDepositProcessorTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/savings/service/SavingsDepositProcessorTest.java
@@ -1,0 +1,110 @@
+package rs.raf.banka2_bek.savings.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import rs.raf.banka2_bek.account.model.Account;
+import rs.raf.banka2_bek.account.repository.AccountRepository;
+import rs.raf.banka2_bek.currency.model.Currency;
+import rs.raf.banka2_bek.savings.entity.SavingsDeposit;
+import rs.raf.banka2_bek.savings.entity.SavingsDepositStatus;
+import rs.raf.banka2_bek.savings.entity.SavingsInterestRate;
+import rs.raf.banka2_bek.savings.entity.SavingsTransaction;
+import rs.raf.banka2_bek.savings.repository.SavingsDepositRepository;
+import rs.raf.banka2_bek.savings.repository.SavingsTransactionRepository;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SavingsDepositProcessorTest {
+
+    @Mock SavingsDepositRepository depositRepo;
+    @Mock SavingsTransactionRepository txRepo;
+    @Mock SavingsInterestRateService rateService;
+    @Mock AccountRepository accountRepo;
+    @InjectMocks SavingsDepositProcessor processor;
+
+    private Currency rsd;
+    private SavingsDeposit deposit;
+    private Account linked;
+
+    @BeforeEach
+    void setUp() {
+        rsd = new Currency();
+        rsd.setId(1L);
+        rsd.setCode("RSD");
+
+        deposit = SavingsDeposit.builder()
+                .id(1L).clientId(1L).linkedAccountId(10L)
+                .principalAmount(new BigDecimal("100000"))
+                .currency(rsd).termMonths(12)
+                .annualInterestRate(new BigDecimal("4.00"))
+                .startDate(LocalDate.of(2026, 5, 12))
+                .maturityDate(LocalDate.of(2027, 5, 12))
+                .nextInterestPaymentDate(LocalDate.of(2026, 6, 12))
+                .totalInterestPaid(BigDecimal.ZERO)
+                .autoRenew(false)
+                .status(SavingsDepositStatus.ACTIVE).build();
+
+        linked = new Account();
+        linked.setId(10L);
+        linked.setBalance(new BigDecimal("1000"));
+        linked.setAvailableBalance(new BigDecimal("1000"));
+        linked.setCurrency(rsd);
+    }
+
+    @Test
+    void payMonthlyInterest_creditsLinkedAndUpdatesNextDate() {
+        when(accountRepo.findForUpdateById(10L)).thenReturn(Optional.of(linked));
+        when(accountRepo.save(linked)).thenReturn(linked);
+        when(depositRepo.save(deposit)).thenReturn(deposit);
+
+        processor.payMonthlyInterest(deposit, LocalDate.of(2026, 6, 12));
+
+        // 100000 * 4.00 / 1200 = 333.3333
+        assertThat(linked.getBalance()).isEqualByComparingTo("1333.3333");
+        assertThat(linked.getAvailableBalance()).isEqualByComparingTo("1333.3333");
+        assertThat(deposit.getNextInterestPaymentDate()).isEqualTo(LocalDate.of(2026, 7, 12));
+        assertThat(deposit.getTotalInterestPaid()).isEqualByComparingTo("333.3333");
+        verify(txRepo).save(any(SavingsTransaction.class));
+    }
+
+    @Test
+    void returnPrincipal_setsStatusMatured() {
+        when(accountRepo.findForUpdateById(10L)).thenReturn(Optional.of(linked));
+        when(accountRepo.save(linked)).thenReturn(linked);
+        when(depositRepo.save(deposit)).thenReturn(deposit);
+
+        processor.returnPrincipal(deposit, LocalDate.of(2027, 5, 12));
+
+        assertThat(deposit.getStatus()).isEqualTo(SavingsDepositStatus.MATURED);
+        assertThat(linked.getBalance()).isEqualByComparingTo("101000");
+        verify(txRepo).save(any(SavingsTransaction.class));
+    }
+
+    @Test
+    void renewDeposit_createsNewWithCurrentRate() {
+        SavingsInterestRate currentRate = SavingsInterestRate.builder()
+                .id(2L).currency(rsd).termMonths(12).annualRate(new BigDecimal("4.50"))
+                .active(true).effectiveFrom(LocalDate.now()).build();
+        when(rateService.findActive(1L, 12)).thenReturn(Optional.of(currentRate));
+        when(depositRepo.save(any(SavingsDeposit.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        processor.renewDeposit(deposit, LocalDate.of(2027, 5, 12));
+
+        assertThat(deposit.getStatus()).isEqualTo(SavingsDepositStatus.RENEWED);
+        verify(depositRepo, times(2)).save(any(SavingsDeposit.class));
+        verify(txRepo).save(any(SavingsTransaction.class));
+    }
+}

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/savings/service/SavingsDepositServiceTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/savings/service/SavingsDepositServiceTest.java
@@ -27,6 +27,9 @@ import rs.raf.banka2_bek.savings.dto.WithdrawEarlyDto;
 import rs.raf.banka2_bek.savings.entity.SavingsDeposit;
 import rs.raf.banka2_bek.savings.entity.SavingsDepositStatus;
 import rs.raf.banka2_bek.savings.entity.SavingsInterestRate;
+import rs.raf.banka2_bek.savings.entity.SavingsTransaction;
+import rs.raf.banka2_bek.savings.entity.SavingsTransactionType;
+import rs.raf.banka2_bek.savings.exception.SavingsDepositNotFoundException;
 import rs.raf.banka2_bek.savings.mapper.SavingsMapper;
 import rs.raf.banka2_bek.savings.repository.SavingsDepositRepository;
 import rs.raf.banka2_bek.savings.repository.SavingsTransactionRepository;
@@ -162,6 +165,49 @@ class SavingsDepositServiceTest {
     }
 
     @Test
+    void openDeposit_happyPath_rsd_12months_debitsSourceAndCreatesDeposit() {
+        when(userResolver.resolveCurrent()).thenReturn(new UserContext(1L, UserRole.CLIENT));
+        when(otpService.verify(anyString(), eq("123456"))).thenReturn(Map.of("verified", true));
+        when(accountRepo.findById(10L)).thenReturn(Optional.of(source));
+
+        SavingsInterestRate rate = SavingsInterestRate.builder()
+                .id(1L).currency(rsd).termMonths(12).annualRate(new BigDecimal("4.00"))
+                .active(true).effectiveFrom(LocalDate.now()).build();
+        when(rateService.findActive(1L, 12)).thenReturn(Optional.of(rate));
+
+        // depositRepo.save returns entity sa id-em postavljenim
+        when(depositRepo.save(any(SavingsDeposit.class))).thenAnswer(inv -> {
+            SavingsDeposit d = inv.getArgument(0);
+            d.setId(99L);
+            return d;
+        });
+        SavingsDepositDto outDto = SavingsDepositDto.builder().id(99L).principalAmount(new BigDecimal("100000")).build();
+        when(mapper.toDepositDto(any(SavingsDeposit.class))).thenReturn(outDto);
+
+        OpenDepositDto dto = OpenDepositDto.builder()
+                .sourceAccountId(10L).linkedAccountId(10L)
+                .principalAmount(new BigDecimal("100000"))
+                .termMonths(12)
+                .autoRenew(true).otpCode("123456")
+                .build();
+
+        SavingsDepositDto result = service.openDeposit(dto);
+
+        // Source account debituje za principal
+        assertThat(source.getBalance()).isEqualByComparingTo("400000");
+        assertThat(source.getAvailableBalance()).isEqualByComparingTo("400000");
+        verify(accountRepo).save(source);
+
+        // Deposit zapisan + audit transaction kreirana
+        verify(depositRepo).save(any(SavingsDeposit.class));
+        verify(txRepo).save(any(SavingsTransaction.class));
+
+        // Vraca DTO sa id-em
+        assertThat(result.getId()).isEqualTo(99L);
+        assertThat(result.getPrincipalAmount()).isEqualByComparingTo("100000");
+    }
+
+    @Test
     void openDeposit_insufficientBalance_throws() {
         when(userResolver.resolveCurrent()).thenReturn(new UserContext(1L, UserRole.CLIENT));
         when(otpService.verify(anyString(), eq("123456"))).thenReturn(Map.of("verified", true));
@@ -242,6 +288,70 @@ class SavingsDepositServiceTest {
     // -----------------------------------------------------------------------
     // withdrawEarly
     // -----------------------------------------------------------------------
+
+    @Test
+    void getDeposit_notFound_throws404() {
+        when(depositRepo.findById(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getDeposit(999L))
+                .isInstanceOf(SavingsDepositNotFoundException.class)
+                .hasMessageContaining("999");
+    }
+
+    @Test
+    void withdrawEarly_happyPath_returnsPrincipalMinusPenaltyAndPenaltyToBank() {
+        SavingsDeposit d = SavingsDeposit.builder()
+                .id(1L).clientId(1L).linkedAccountId(10L)
+                .principalAmount(new BigDecimal("100000"))
+                .currency(rsd).termMonths(12)
+                .annualInterestRate(new BigDecimal("4.00"))
+                .startDate(LocalDate.now()).maturityDate(LocalDate.now().plusMonths(12))
+                .nextInterestPaymentDate(LocalDate.now().plusMonths(1))
+                .totalInterestPaid(BigDecimal.ZERO)
+                .autoRenew(false).status(SavingsDepositStatus.ACTIVE).build();
+        when(depositRepo.findById(1L)).thenReturn(Optional.of(d));
+        when(userResolver.resolveCurrent()).thenReturn(new UserContext(1L, UserRole.CLIENT));
+        when(otpService.verify(anyString(), eq("123456"))).thenReturn(Map.of("verified", true));
+
+        Account linked = new Account();
+        linked.setId(10L);
+        linked.setBalance(new BigDecimal("5000"));
+        linked.setAvailableBalance(new BigDecimal("5000"));
+        linked.setCurrency(rsd);
+        when(accountRepo.findForUpdateById(10L)).thenReturn(Optional.of(linked));
+
+        Account bankAccount = new Account();
+        bankAccount.setId(100L);
+        bankAccount.setBalance(new BigDecimal("1000000"));
+        bankAccount.setAvailableBalance(new BigDecimal("1000000"));
+        bankAccount.setCurrency(rsd);
+        when(accountRepo.findBankAccountByCurrencyId("22200022", 1L)).thenReturn(Optional.of(bankAccount));
+
+        when(depositRepo.save(d)).thenReturn(d);
+        SavingsDepositDto outDto = SavingsDepositDto.builder().id(1L).status("WITHDRAWN_EARLY").build();
+        when(mapper.toDepositDto(d)).thenReturn(outDto);
+
+        WithdrawEarlyDto dto = new WithdrawEarlyDto();
+        dto.setOtpCode("123456");
+
+        SavingsDepositDto result = service.withdrawEarly(1L, dto);
+
+        // Penal = 100000 * 0.01 = 1000.0000
+        // Vracen iznos = 100000 - 1000 = 99000
+        // Linked account: 5000 + 99000 = 104000
+        assertThat(linked.getBalance()).isEqualByComparingTo("104000");
+        assertThat(linked.getAvailableBalance()).isEqualByComparingTo("104000");
+
+        // Bankin racun: 1000000 + 1000 = 1001000
+        assertThat(bankAccount.getBalance()).isEqualByComparingTo("1001000");
+
+        assertThat(d.getStatus()).isEqualTo(SavingsDepositStatus.WITHDRAWN_EARLY);
+        verify(txRepo, times(2)).save(any(SavingsTransaction.class)); // PRINCIPAL + PENALTY
+        verify(accountRepo).save(linked);
+        verify(accountRepo).save(bankAccount);
+
+        assertThat(result.getStatus()).isEqualTo("WITHDRAWN_EARLY");
+    }
 
     @Test
     void withdrawEarly_notActive_throws() {

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/savings/service/SavingsDepositServiceTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/savings/service/SavingsDepositServiceTest.java
@@ -1,0 +1,324 @@
+package rs.raf.banka2_bek.savings.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.util.ReflectionTestUtils;
+import rs.raf.banka2_bek.account.model.Account;
+import rs.raf.banka2_bek.account.model.AccountStatus;
+import rs.raf.banka2_bek.account.repository.AccountRepository;
+import rs.raf.banka2_bek.auth.util.UserContext;
+import rs.raf.banka2_bek.auth.util.UserResolver;
+import rs.raf.banka2_bek.auth.util.UserRole;
+import rs.raf.banka2_bek.client.model.Client;
+import rs.raf.banka2_bek.currency.model.Currency;
+import rs.raf.banka2_bek.otp.service.OtpService;
+import rs.raf.banka2_bek.savings.dto.OpenDepositDto;
+import rs.raf.banka2_bek.savings.dto.SavingsDepositDto;
+import rs.raf.banka2_bek.savings.dto.ToggleAutoRenewDto;
+import rs.raf.banka2_bek.savings.dto.WithdrawEarlyDto;
+import rs.raf.banka2_bek.savings.entity.SavingsDeposit;
+import rs.raf.banka2_bek.savings.entity.SavingsDepositStatus;
+import rs.raf.banka2_bek.savings.entity.SavingsInterestRate;
+import rs.raf.banka2_bek.savings.mapper.SavingsMapper;
+import rs.raf.banka2_bek.savings.repository.SavingsDepositRepository;
+import rs.raf.banka2_bek.savings.repository.SavingsTransactionRepository;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SavingsDepositServiceTest {
+
+    @Mock SavingsDepositRepository depositRepo;
+    @Mock SavingsTransactionRepository txRepo;
+    @Mock SavingsInterestRateService rateService;
+    @Mock SavingsMapper mapper;
+    @Mock AccountRepository accountRepo;
+    @Mock UserResolver userResolver;
+    @Mock OtpService otpService;
+
+    @InjectMocks SavingsDepositService service;
+
+    private Currency rsd;
+    private Client client;
+    private Account source;
+
+    @BeforeEach
+    void setUp() {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken("stefan@gmail.com", "x", List.of()));
+
+        rsd = new Currency();
+        rsd.setId(1L);
+        rsd.setCode("RSD");
+
+        client = new Client();
+        client.setId(1L);
+
+        source = new Account();
+        source.setId(10L);
+        source.setAccountNumber("222000132199251311");
+        source.setBalance(new BigDecimal("500000"));
+        source.setAvailableBalance(new BigDecimal("500000"));
+        source.setCurrency(rsd);
+        source.setStatus(AccountStatus.ACTIVE);
+        source.setClient(client);
+
+        ReflectionTestUtils.setField(service, "bankRegistrationNumber", "22200022");
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    // -----------------------------------------------------------------------
+    // openDeposit tests
+    // -----------------------------------------------------------------------
+
+    @Test
+    void openDeposit_employeeCannotOpen() {
+        when(userResolver.resolveCurrent()).thenReturn(new UserContext(1L, UserRole.EMPLOYEE));
+
+        OpenDepositDto dto = OpenDepositDto.builder()
+                .sourceAccountId(10L).linkedAccountId(10L)
+                .principalAmount(new BigDecimal("50000"))
+                .termMonths(12)
+                .autoRenew(false).otpCode("123456")
+                .build();
+
+        assertThatThrownBy(() -> service.openDeposit(dto))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("klijenti");
+    }
+
+    @Test
+    void openDeposit_invalidTerm_throws() {
+        when(userResolver.resolveCurrent()).thenReturn(new UserContext(1L, UserRole.CLIENT));
+        when(otpService.verify(anyString(), eq("123456"))).thenReturn(Map.of("verified", true));
+
+        OpenDepositDto dto = OpenDepositDto.builder()
+                .sourceAccountId(10L).linkedAccountId(10L)
+                .principalAmount(new BigDecimal("50000"))
+                .termMonths(7) // not in {3,6,12,24,36}
+                .autoRenew(false).otpCode("123456")
+                .build();
+
+        assertThatThrownBy(() -> service.openDeposit(dto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("3, 6, 12, 24, 36");
+    }
+
+    @Test
+    void openDeposit_belowMinimum_throws() {
+        when(userResolver.resolveCurrent()).thenReturn(new UserContext(1L, UserRole.CLIENT));
+        when(otpService.verify(anyString(), eq("123456"))).thenReturn(Map.of("verified", true));
+        // source account lookup (term=12 is valid, so passes VALID_TERMS check)
+        when(accountRepo.findById(10L)).thenReturn(Optional.of(source));
+
+        OpenDepositDto dto = OpenDepositDto.builder()
+                .sourceAccountId(10L).linkedAccountId(10L)
+                .principalAmount(new BigDecimal("5000")) // < 10000 RSD minimum
+                .termMonths(12)
+                .autoRenew(false).otpCode("123456")
+                .build();
+
+        assertThatThrownBy(() -> service.openDeposit(dto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Minimalan iznos");
+    }
+
+    @Test
+    void openDeposit_otpFailed_throws() {
+        when(userResolver.resolveCurrent()).thenReturn(new UserContext(1L, UserRole.CLIENT));
+        when(otpService.verify(anyString(), eq("000000"))).thenReturn(Map.of("verified", false));
+
+        OpenDepositDto dto = OpenDepositDto.builder()
+                .sourceAccountId(10L).linkedAccountId(10L)
+                .principalAmount(new BigDecimal("50000"))
+                .termMonths(12)
+                .autoRenew(false).otpCode("000000")
+                .build();
+
+        assertThatThrownBy(() -> service.openDeposit(dto))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("OTP");
+    }
+
+    @Test
+    void openDeposit_insufficientBalance_throws() {
+        when(userResolver.resolveCurrent()).thenReturn(new UserContext(1L, UserRole.CLIENT));
+        when(otpService.verify(anyString(), eq("123456"))).thenReturn(Map.of("verified", true));
+
+        source.setAvailableBalance(new BigDecimal("5000")); // less than requested
+        when(accountRepo.findById(10L)).thenReturn(Optional.of(source));
+
+        SavingsInterestRate rate = SavingsInterestRate.builder()
+                .id(1L).currency(rsd).termMonths(12).annualRate(new BigDecimal("4.00"))
+                .active(true).effectiveFrom(LocalDate.now()).build();
+        when(rateService.findActive(1L, 12)).thenReturn(Optional.of(rate));
+
+        OpenDepositDto dto = OpenDepositDto.builder()
+                .sourceAccountId(10L).linkedAccountId(10L)
+                .principalAmount(new BigDecimal("50000")) // > 5000 available
+                .termMonths(12)
+                .autoRenew(false).otpCode("123456")
+                .build();
+
+        assertThatThrownBy(() -> service.openDeposit(dto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Nedovoljno");
+    }
+
+    // -----------------------------------------------------------------------
+    // listMyDeposits
+    // -----------------------------------------------------------------------
+
+    @Test
+    void listMyDeposits_returnsOwned() {
+        when(userResolver.resolveCurrent()).thenReturn(new UserContext(1L, UserRole.CLIENT));
+        SavingsDeposit d = SavingsDeposit.builder().id(1L).clientId(1L).build();
+        SavingsDepositDto dto = SavingsDepositDto.builder().id(1L).build();
+        when(depositRepo.findByClientIdOrderByCreatedAtDesc(1L)).thenReturn(List.of(d));
+        when(mapper.toDepositDto(d)).thenReturn(dto);
+
+        List<SavingsDepositDto> result = service.listMyDeposits();
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(1L);
+    }
+
+    @Test
+    void listMyDeposits_empty() {
+        when(userResolver.resolveCurrent()).thenReturn(new UserContext(2L, UserRole.CLIENT));
+        when(depositRepo.findByClientIdOrderByCreatedAtDesc(2L)).thenReturn(List.of());
+
+        List<SavingsDepositDto> result = service.listMyDeposits();
+        assertThat(result).isEmpty();
+    }
+
+    // -----------------------------------------------------------------------
+    // getDeposit
+    // -----------------------------------------------------------------------
+
+    @Test
+    void getDeposit_clientOwnsIt_returnsDto() {
+        SavingsDeposit d = SavingsDeposit.builder().id(1L).clientId(1L).status(SavingsDepositStatus.ACTIVE).build();
+        SavingsDepositDto dto = SavingsDepositDto.builder().id(1L).build();
+        when(depositRepo.findById(1L)).thenReturn(Optional.of(d));
+        when(userResolver.resolveCurrent()).thenReturn(new UserContext(1L, UserRole.CLIENT));
+        when(mapper.toDepositDto(d)).thenReturn(dto);
+
+        SavingsDepositDto result = service.getDeposit(1L);
+        assertThat(result.getId()).isEqualTo(1L);
+    }
+
+    @Test
+    void getDeposit_employee_throws403() {
+        SavingsDeposit d = SavingsDeposit.builder().id(1L).clientId(1L).status(SavingsDepositStatus.ACTIVE).build();
+        when(depositRepo.findById(1L)).thenReturn(Optional.of(d));
+        when(userResolver.resolveCurrent()).thenReturn(new UserContext(99L, UserRole.EMPLOYEE));
+
+        assertThatThrownBy(() -> service.getDeposit(1L))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("admin");
+    }
+
+    // -----------------------------------------------------------------------
+    // withdrawEarly
+    // -----------------------------------------------------------------------
+
+    @Test
+    void withdrawEarly_notActive_throws() {
+        SavingsDeposit d = SavingsDeposit.builder()
+                .id(1L).clientId(1L)
+                .status(SavingsDepositStatus.MATURED)
+                .build();
+        when(depositRepo.findById(1L)).thenReturn(Optional.of(d));
+        when(userResolver.resolveCurrent()).thenReturn(new UserContext(1L, UserRole.CLIENT));
+
+        WithdrawEarlyDto dto = new WithdrawEarlyDto();
+        dto.setOtpCode("123456");
+
+        assertThatThrownBy(() -> service.withdrawEarly(1L, dto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("nije aktivan");
+    }
+
+    @Test
+    void withdrawEarly_notOwner_throws403() {
+        SavingsDeposit d = SavingsDeposit.builder()
+                .id(1L).clientId(99L) // different client
+                .status(SavingsDepositStatus.ACTIVE)
+                .build();
+        when(depositRepo.findById(1L)).thenReturn(Optional.of(d));
+        when(userResolver.resolveCurrent()).thenReturn(new UserContext(1L, UserRole.CLIENT));
+
+        WithdrawEarlyDto dto = new WithdrawEarlyDto();
+        dto.setOtpCode("123456");
+
+        assertThatThrownBy(() -> service.withdrawEarly(1L, dto))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("Depozit ne pripada");
+    }
+
+    // -----------------------------------------------------------------------
+    // toggleAutoRenew
+    // -----------------------------------------------------------------------
+
+    @Test
+    void toggleAutoRenew_happyPath() {
+        SavingsDeposit d = SavingsDeposit.builder()
+                .id(1L).clientId(1L)
+                .autoRenew(false)
+                .status(SavingsDepositStatus.ACTIVE)
+                .build();
+        when(depositRepo.findById(1L)).thenReturn(Optional.of(d));
+        when(userResolver.resolveCurrent()).thenReturn(new UserContext(1L, UserRole.CLIENT));
+        when(depositRepo.save(d)).thenReturn(d);
+        SavingsDepositDto outDto = SavingsDepositDto.builder().id(1L).autoRenew(true).build();
+        when(mapper.toDepositDto(d)).thenReturn(outDto);
+
+        ToggleAutoRenewDto toggleDto = new ToggleAutoRenewDto();
+        toggleDto.setAutoRenew(true);
+
+        SavingsDepositDto result = service.toggleAutoRenew(1L, toggleDto);
+
+        assertThat(d.getAutoRenew()).isTrue();
+        verify(depositRepo).save(d);
+        assertThat(result.getAutoRenew()).isTrue();
+    }
+
+    @Test
+    void toggleAutoRenew_notActive_throws() {
+        SavingsDeposit d = SavingsDeposit.builder()
+                .id(1L).clientId(1L)
+                .autoRenew(false)
+                .status(SavingsDepositStatus.MATURED)
+                .build();
+        when(depositRepo.findById(1L)).thenReturn(Optional.of(d));
+        when(userResolver.resolveCurrent()).thenReturn(new UserContext(1L, UserRole.CLIENT));
+
+        ToggleAutoRenewDto toggleDto = new ToggleAutoRenewDto();
+        toggleDto.setAutoRenew(true);
+
+        assertThatThrownBy(() -> service.toggleAutoRenew(1L, toggleDto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("aktivnim");
+    }
+}

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/savings/service/SavingsInterestRateServiceTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/savings/service/SavingsInterestRateServiceTest.java
@@ -1,0 +1,149 @@
+package rs.raf.banka2_bek.savings.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import rs.raf.banka2_bek.currency.model.Currency;
+import rs.raf.banka2_bek.currency.repository.CurrencyRepository;
+import rs.raf.banka2_bek.savings.dto.SavingsRateDto;
+import rs.raf.banka2_bek.savings.dto.UpsertSavingsRateDto;
+import rs.raf.banka2_bek.savings.entity.SavingsInterestRate;
+import rs.raf.banka2_bek.savings.mapper.SavingsMapper;
+import rs.raf.banka2_bek.savings.repository.SavingsInterestRateRepository;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SavingsInterestRateServiceTest {
+
+    @Mock SavingsInterestRateRepository rateRepo;
+    @Mock CurrencyRepository currencyRepo;
+    @Mock SavingsMapper mapper;
+    @InjectMocks SavingsInterestRateService service;
+
+    private Currency rsd() {
+        Currency c = new Currency();
+        c.setId(1L);
+        c.setCode("RSD");
+        return c;
+    }
+
+    @Test
+    void findActive_returnsRate() {
+        SavingsInterestRate rate = SavingsInterestRate.builder()
+                .id(1L).currency(rsd()).termMonths(12).annualRate(new BigDecimal("4.00"))
+                .active(true).effectiveFrom(LocalDate.now()).build();
+        when(rateRepo.findActive(1L, 12)).thenReturn(Optional.of(rate));
+
+        Optional<SavingsInterestRate> result = service.findActive(1L, 12);
+        assertThat(result).isPresent();
+        assertThat(result.get().getAnnualRate()).isEqualByComparingTo("4.00");
+    }
+
+    @Test
+    void findActive_empty() {
+        when(rateRepo.findActive(99L, 7)).thenReturn(Optional.empty());
+        assertThat(service.findActive(99L, 7)).isEmpty();
+    }
+
+    @Test
+    void listActive_byCurrencyCode_filters() {
+        SavingsInterestRate r = SavingsInterestRate.builder()
+                .id(1L).currency(rsd()).termMonths(12).annualRate(new BigDecimal("4.00"))
+                .active(true).effectiveFrom(LocalDate.now()).build();
+        SavingsRateDto dto = SavingsRateDto.builder().id(1L).currencyCode("RSD").termMonths(12).build();
+        when(rateRepo.findActiveByCurrencyCode("RSD")).thenReturn(List.of(r));
+        when(mapper.toRateDto(r)).thenReturn(dto);
+
+        List<SavingsRateDto> result = service.listActive("RSD");
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCurrencyCode()).isEqualTo("RSD");
+    }
+
+    @Test
+    void listActive_noCurrency_returnsAll() {
+        when(rateRepo.findAllActive()).thenReturn(List.of());
+        assertThat(service.listActive(null)).isEmpty();
+    }
+
+    @Test
+    void listAll_delegatesToRepo() {
+        when(rateRepo.findAll()).thenReturn(List.of());
+        assertThat(service.listAll()).isEmpty();
+        verify(rateRepo).findAll();
+    }
+
+    @Test
+    void upsert_deactivatesExistingAndCreatesNew() {
+        Currency c = rsd();
+        SavingsInterestRate existing = SavingsInterestRate.builder()
+                .id(1L).currency(c).termMonths(12).annualRate(new BigDecimal("3.50"))
+                .active(true).effectiveFrom(LocalDate.now().minusMonths(2)).build();
+
+        UpsertSavingsRateDto dto = new UpsertSavingsRateDto();
+        dto.setCurrencyCode("RSD");
+        dto.setTermMonths(12);
+        dto.setAnnualRate(new BigDecimal("4.25"));
+
+        when(currencyRepo.findByCode("RSD")).thenReturn(Optional.of(c));
+        when(rateRepo.findActive(1L, 12)).thenReturn(Optional.of(existing));
+        when(rateRepo.save(any(SavingsInterestRate.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(mapper.toRateDto(any(SavingsInterestRate.class))).thenAnswer(inv -> {
+            SavingsInterestRate r = inv.getArgument(0);
+            return SavingsRateDto.builder().annualRate(r.getAnnualRate()).build();
+        });
+
+        SavingsRateDto result = service.upsert(dto);
+
+        assertThat(existing.getActive()).isFalse();
+        assertThat(result.getAnnualRate()).isEqualByComparingTo("4.25");
+        // existing (deactivated) + new rate = 2 saves
+        verify(rateRepo, times(2)).save(any(SavingsInterestRate.class));
+    }
+
+    @Test
+    void upsert_noExistingRate_createsNew() {
+        Currency c = rsd();
+        UpsertSavingsRateDto dto = new UpsertSavingsRateDto();
+        dto.setCurrencyCode("RSD");
+        dto.setTermMonths(6);
+        dto.setAnnualRate(new BigDecimal("3.00"));
+
+        when(currencyRepo.findByCode("RSD")).thenReturn(Optional.of(c));
+        when(rateRepo.findActive(1L, 6)).thenReturn(Optional.empty());
+        when(rateRepo.save(any(SavingsInterestRate.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(mapper.toRateDto(any(SavingsInterestRate.class))).thenAnswer(inv -> {
+            SavingsInterestRate r = inv.getArgument(0);
+            return SavingsRateDto.builder().annualRate(r.getAnnualRate()).termMonths(r.getTermMonths()).build();
+        });
+
+        SavingsRateDto result = service.upsert(dto);
+
+        assertThat(result.getAnnualRate()).isEqualByComparingTo("3.00");
+        // only new rate saved (no existing to deactivate)
+        verify(rateRepo, times(1)).save(any(SavingsInterestRate.class));
+    }
+
+    @Test
+    void upsert_currencyNotFound_throws() {
+        UpsertSavingsRateDto dto = new UpsertSavingsRateDto();
+        dto.setCurrencyCode("XYZ");
+        dto.setTermMonths(12);
+        dto.setAnnualRate(new BigDecimal("4.00"));
+        when(currencyRepo.findByCode("XYZ")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.upsert(dto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Valuta ne postoji");
+    }
+}

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/savings/service/SavingsSchedulerTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/savings/service/SavingsSchedulerTest.java
@@ -6,37 +6,31 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import rs.raf.banka2_bek.account.model.Account;
-import rs.raf.banka2_bek.account.repository.AccountRepository;
 import rs.raf.banka2_bek.currency.model.Currency;
 import rs.raf.banka2_bek.savings.entity.SavingsDeposit;
 import rs.raf.banka2_bek.savings.entity.SavingsDepositStatus;
-import rs.raf.banka2_bek.savings.entity.SavingsInterestRate;
-import rs.raf.banka2_bek.savings.entity.SavingsTransaction;
 import rs.raf.banka2_bek.savings.repository.SavingsDepositRepository;
-import rs.raf.banka2_bek.savings.repository.SavingsTransactionRepository;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class SavingsSchedulerTest {
 
     @Mock SavingsDepositRepository depositRepo;
-    @Mock SavingsTransactionRepository txRepo;
-    @Mock SavingsInterestRateService rateService;
-    @Mock AccountRepository accountRepo;
+    @Mock SavingsDepositProcessor processor;
     @InjectMocks SavingsScheduler scheduler;
 
     private Currency rsd;
     private SavingsDeposit deposit;
-    private Account linked;
 
     @BeforeEach
     void setUp() {
@@ -55,58 +49,6 @@ class SavingsSchedulerTest {
                 .totalInterestPaid(BigDecimal.ZERO)
                 .autoRenew(false)
                 .status(SavingsDepositStatus.ACTIVE).build();
-
-        linked = new Account();
-        linked.setId(10L);
-        linked.setBalance(new BigDecimal("1000"));
-        linked.setAvailableBalance(new BigDecimal("1000"));
-        linked.setCurrency(rsd);
-    }
-
-    @Test
-    void payMonthlyInterest_creditsLinkedAndUpdatesNextDate() {
-        when(accountRepo.findForUpdateById(10L)).thenReturn(Optional.of(linked));
-        when(accountRepo.save(linked)).thenReturn(linked);
-        when(depositRepo.save(deposit)).thenReturn(deposit);
-
-        scheduler.payMonthlyInterest(deposit, LocalDate.of(2026, 6, 12));
-
-        // 100000 * 4.00 / 1200 = 333.3333
-        assertThat(linked.getBalance()).isEqualByComparingTo("1333.3333");
-        assertThat(linked.getAvailableBalance()).isEqualByComparingTo("1333.3333");
-        assertThat(deposit.getNextInterestPaymentDate()).isEqualTo(LocalDate.of(2026, 7, 12));
-        assertThat(deposit.getTotalInterestPaid()).isEqualByComparingTo("333.3333");
-        verify(txRepo).save(any(SavingsTransaction.class));
-    }
-
-    @Test
-    void returnPrincipal_setsStatusMatured() {
-        when(accountRepo.findForUpdateById(10L)).thenReturn(Optional.of(linked));
-        when(accountRepo.save(linked)).thenReturn(linked);
-        when(depositRepo.save(deposit)).thenReturn(deposit);
-
-        scheduler.returnPrincipal(deposit, LocalDate.of(2027, 5, 12));
-
-        assertThat(deposit.getStatus()).isEqualTo(SavingsDepositStatus.MATURED);
-        // 1000 + 100000 = 101000
-        assertThat(linked.getBalance()).isEqualByComparingTo("101000");
-        verify(txRepo).save(any(SavingsTransaction.class));
-    }
-
-    @Test
-    void renewDeposit_createsNewWithCurrentRate() {
-        SavingsInterestRate currentRate = SavingsInterestRate.builder()
-                .id(2L).currency(rsd).termMonths(12).annualRate(new BigDecimal("4.50"))
-                .active(true).effectiveFrom(LocalDate.now()).build();
-        when(rateService.findActive(1L, 12)).thenReturn(Optional.of(currentRate));
-        when(depositRepo.save(any(SavingsDeposit.class))).thenAnswer(inv -> inv.getArgument(0));
-
-        scheduler.renewDeposit(deposit, LocalDate.of(2027, 5, 12));
-
-        assertThat(deposit.getStatus()).isEqualTo(SavingsDepositStatus.RENEWED);
-        // old (status RENEWED) + new deposit = 2 saves
-        verify(depositRepo, times(2)).save(any(SavingsDeposit.class));
-        verify(txRepo).save(any(SavingsTransaction.class));
     }
 
     @Test
@@ -120,51 +62,78 @@ class SavingsSchedulerTest {
 
         scheduler.runSavingsCycle();
 
-        verify(txRepo, never()).save(any());
+        verify(processor, never()).payMonthlyInterest(any(), any());
+        verify(processor, never()).returnPrincipal(any(), any());
+        verify(processor, never()).renewDeposit(any(), any());
     }
 
     @Test
-    void runSavingsCycle_autoRenew_callsRenew() {
+    void runSavingsCycle_invokesPayMonthlyInterestForDueDeposits() {
+        when(depositRepo.findByStatusAndNextInterestPaymentDateLessThanEqual(
+                eq(SavingsDepositStatus.ACTIVE), any(LocalDate.class)))
+                .thenReturn(List.of(deposit));
+        when(depositRepo.findByStatusAndMaturityDateLessThanEqual(
+                eq(SavingsDepositStatus.ACTIVE), any(LocalDate.class)))
+                .thenReturn(List.of());
+
+        scheduler.runSavingsCycle();
+
+        verify(processor, times(1)).payMonthlyInterest(eq(deposit), any(LocalDate.class));
+        verify(processor, never()).returnPrincipal(any(), any());
+        verify(processor, never()).renewDeposit(any(), any());
+    }
+
+    @Test
+    void runSavingsCycle_autoRenew_callsRenewOnProcessor() {
         deposit.setAutoRenew(true);
-        deposit.setMaturityDate(LocalDate.now().minusDays(1));
-
-        SavingsInterestRate rate = SavingsInterestRate.builder()
-                .id(2L).currency(rsd).termMonths(12).annualRate(new BigDecimal("4.00"))
-                .active(true).effectiveFrom(LocalDate.now()).build();
-
         when(depositRepo.findByStatusAndNextInterestPaymentDateLessThanEqual(
                 any(SavingsDepositStatus.class), any(LocalDate.class)))
                 .thenReturn(List.of());
         when(depositRepo.findByStatusAndMaturityDateLessThanEqual(
-                any(SavingsDepositStatus.class), any(LocalDate.class)))
+                eq(SavingsDepositStatus.ACTIVE), any(LocalDate.class)))
                 .thenReturn(List.of(deposit));
-        when(rateService.findActive(1L, 12)).thenReturn(Optional.of(rate));
-        when(depositRepo.save(any(SavingsDeposit.class))).thenAnswer(inv -> inv.getArgument(0));
 
         scheduler.runSavingsCycle();
 
-        assertThat(deposit.getStatus()).isEqualTo(SavingsDepositStatus.RENEWED);
-        verify(txRepo, times(1)).save(any(SavingsTransaction.class));
+        verify(processor, times(1)).renewDeposit(eq(deposit), any(LocalDate.class));
+        verify(processor, never()).returnPrincipal(any(), any());
     }
 
     @Test
-    void runSavingsCycle_notAutoRenew_callsReturnPrincipal() {
+    void runSavingsCycle_notAutoRenew_callsReturnPrincipalOnProcessor() {
         deposit.setAutoRenew(false);
-        deposit.setMaturityDate(LocalDate.now().minusDays(1));
-
         when(depositRepo.findByStatusAndNextInterestPaymentDateLessThanEqual(
                 any(SavingsDepositStatus.class), any(LocalDate.class)))
                 .thenReturn(List.of());
         when(depositRepo.findByStatusAndMaturityDateLessThanEqual(
-                any(SavingsDepositStatus.class), any(LocalDate.class)))
+                eq(SavingsDepositStatus.ACTIVE), any(LocalDate.class)))
                 .thenReturn(List.of(deposit));
-        when(accountRepo.findForUpdateById(10L)).thenReturn(Optional.of(linked));
-        when(accountRepo.save(linked)).thenReturn(linked);
-        when(depositRepo.save(deposit)).thenReturn(deposit);
 
         scheduler.runSavingsCycle();
 
-        assertThat(deposit.getStatus()).isEqualTo(SavingsDepositStatus.MATURED);
-        verify(txRepo, times(1)).save(any(SavingsTransaction.class));
+        verify(processor, times(1)).returnPrincipal(eq(deposit), any(LocalDate.class));
+        verify(processor, never()).renewDeposit(any(), any());
+    }
+
+    @Test
+    void runSavingsCycle_swallowsProcessorExceptions() {
+        when(depositRepo.findByStatusAndNextInterestPaymentDateLessThanEqual(
+                any(SavingsDepositStatus.class), any(LocalDate.class)))
+                .thenReturn(List.of(deposit));
+        when(depositRepo.findByStatusAndMaturityDateLessThanEqual(
+                any(SavingsDepositStatus.class), any(LocalDate.class)))
+                .thenReturn(List.of());
+
+        // throw runtime exception — scheduler treba da log-uje i nastavi
+        doThrowOnPayInterest();
+
+        scheduler.runSavingsCycle();
+
+        verify(processor, times(1)).payMonthlyInterest(eq(deposit), any(LocalDate.class));
+    }
+
+    private void doThrowOnPayInterest() {
+        org.mockito.Mockito.doThrow(new IllegalStateException("test"))
+                .when(processor).payMonthlyInterest(any(SavingsDeposit.class), any(LocalDate.class));
     }
 }

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/savings/service/SavingsSchedulerTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/savings/service/SavingsSchedulerTest.java
@@ -1,0 +1,170 @@
+package rs.raf.banka2_bek.savings.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import rs.raf.banka2_bek.account.model.Account;
+import rs.raf.banka2_bek.account.repository.AccountRepository;
+import rs.raf.banka2_bek.currency.model.Currency;
+import rs.raf.banka2_bek.savings.entity.SavingsDeposit;
+import rs.raf.banka2_bek.savings.entity.SavingsDepositStatus;
+import rs.raf.banka2_bek.savings.entity.SavingsInterestRate;
+import rs.raf.banka2_bek.savings.entity.SavingsTransaction;
+import rs.raf.banka2_bek.savings.repository.SavingsDepositRepository;
+import rs.raf.banka2_bek.savings.repository.SavingsTransactionRepository;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SavingsSchedulerTest {
+
+    @Mock SavingsDepositRepository depositRepo;
+    @Mock SavingsTransactionRepository txRepo;
+    @Mock SavingsInterestRateService rateService;
+    @Mock AccountRepository accountRepo;
+    @InjectMocks SavingsScheduler scheduler;
+
+    private Currency rsd;
+    private SavingsDeposit deposit;
+    private Account linked;
+
+    @BeforeEach
+    void setUp() {
+        rsd = new Currency();
+        rsd.setId(1L);
+        rsd.setCode("RSD");
+
+        deposit = SavingsDeposit.builder()
+                .id(1L).clientId(1L).linkedAccountId(10L)
+                .principalAmount(new BigDecimal("100000"))
+                .currency(rsd).termMonths(12)
+                .annualInterestRate(new BigDecimal("4.00"))
+                .startDate(LocalDate.of(2026, 5, 12))
+                .maturityDate(LocalDate.of(2027, 5, 12))
+                .nextInterestPaymentDate(LocalDate.of(2026, 6, 12))
+                .totalInterestPaid(BigDecimal.ZERO)
+                .autoRenew(false)
+                .status(SavingsDepositStatus.ACTIVE).build();
+
+        linked = new Account();
+        linked.setId(10L);
+        linked.setBalance(new BigDecimal("1000"));
+        linked.setAvailableBalance(new BigDecimal("1000"));
+        linked.setCurrency(rsd);
+    }
+
+    @Test
+    void payMonthlyInterest_creditsLinkedAndUpdatesNextDate() {
+        when(accountRepo.findForUpdateById(10L)).thenReturn(Optional.of(linked));
+        when(accountRepo.save(linked)).thenReturn(linked);
+        when(depositRepo.save(deposit)).thenReturn(deposit);
+
+        scheduler.payMonthlyInterest(deposit, LocalDate.of(2026, 6, 12));
+
+        // 100000 * 4.00 / 1200 = 333.3333
+        assertThat(linked.getBalance()).isEqualByComparingTo("1333.3333");
+        assertThat(linked.getAvailableBalance()).isEqualByComparingTo("1333.3333");
+        assertThat(deposit.getNextInterestPaymentDate()).isEqualTo(LocalDate.of(2026, 7, 12));
+        assertThat(deposit.getTotalInterestPaid()).isEqualByComparingTo("333.3333");
+        verify(txRepo).save(any(SavingsTransaction.class));
+    }
+
+    @Test
+    void returnPrincipal_setsStatusMatured() {
+        when(accountRepo.findForUpdateById(10L)).thenReturn(Optional.of(linked));
+        when(accountRepo.save(linked)).thenReturn(linked);
+        when(depositRepo.save(deposit)).thenReturn(deposit);
+
+        scheduler.returnPrincipal(deposit, LocalDate.of(2027, 5, 12));
+
+        assertThat(deposit.getStatus()).isEqualTo(SavingsDepositStatus.MATURED);
+        // 1000 + 100000 = 101000
+        assertThat(linked.getBalance()).isEqualByComparingTo("101000");
+        verify(txRepo).save(any(SavingsTransaction.class));
+    }
+
+    @Test
+    void renewDeposit_createsNewWithCurrentRate() {
+        SavingsInterestRate currentRate = SavingsInterestRate.builder()
+                .id(2L).currency(rsd).termMonths(12).annualRate(new BigDecimal("4.50"))
+                .active(true).effectiveFrom(LocalDate.now()).build();
+        when(rateService.findActive(1L, 12)).thenReturn(Optional.of(currentRate));
+        when(depositRepo.save(any(SavingsDeposit.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        scheduler.renewDeposit(deposit, LocalDate.of(2027, 5, 12));
+
+        assertThat(deposit.getStatus()).isEqualTo(SavingsDepositStatus.RENEWED);
+        // old (status RENEWED) + new deposit = 2 saves
+        verify(depositRepo, times(2)).save(any(SavingsDeposit.class));
+        verify(txRepo).save(any(SavingsTransaction.class));
+    }
+
+    @Test
+    void runSavingsCycle_processesNoDeposits() {
+        when(depositRepo.findByStatusAndNextInterestPaymentDateLessThanEqual(
+                any(SavingsDepositStatus.class), any(LocalDate.class)))
+                .thenReturn(List.of());
+        when(depositRepo.findByStatusAndMaturityDateLessThanEqual(
+                any(SavingsDepositStatus.class), any(LocalDate.class)))
+                .thenReturn(List.of());
+
+        scheduler.runSavingsCycle();
+
+        verify(txRepo, never()).save(any());
+    }
+
+    @Test
+    void runSavingsCycle_autoRenew_callsRenew() {
+        deposit.setAutoRenew(true);
+        deposit.setMaturityDate(LocalDate.now().minusDays(1));
+
+        SavingsInterestRate rate = SavingsInterestRate.builder()
+                .id(2L).currency(rsd).termMonths(12).annualRate(new BigDecimal("4.00"))
+                .active(true).effectiveFrom(LocalDate.now()).build();
+
+        when(depositRepo.findByStatusAndNextInterestPaymentDateLessThanEqual(
+                any(SavingsDepositStatus.class), any(LocalDate.class)))
+                .thenReturn(List.of());
+        when(depositRepo.findByStatusAndMaturityDateLessThanEqual(
+                any(SavingsDepositStatus.class), any(LocalDate.class)))
+                .thenReturn(List.of(deposit));
+        when(rateService.findActive(1L, 12)).thenReturn(Optional.of(rate));
+        when(depositRepo.save(any(SavingsDeposit.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        scheduler.runSavingsCycle();
+
+        assertThat(deposit.getStatus()).isEqualTo(SavingsDepositStatus.RENEWED);
+        verify(txRepo, times(1)).save(any(SavingsTransaction.class));
+    }
+
+    @Test
+    void runSavingsCycle_notAutoRenew_callsReturnPrincipal() {
+        deposit.setAutoRenew(false);
+        deposit.setMaturityDate(LocalDate.now().minusDays(1));
+
+        when(depositRepo.findByStatusAndNextInterestPaymentDateLessThanEqual(
+                any(SavingsDepositStatus.class), any(LocalDate.class)))
+                .thenReturn(List.of());
+        when(depositRepo.findByStatusAndMaturityDateLessThanEqual(
+                any(SavingsDepositStatus.class), any(LocalDate.class)))
+                .thenReturn(List.of(deposit));
+        when(accountRepo.findForUpdateById(10L)).thenReturn(Optional.of(linked));
+        when(accountRepo.save(linked)).thenReturn(linked);
+        when(depositRepo.save(deposit)).thenReturn(deposit);
+
+        scheduler.runSavingsCycle();
+
+        assertThat(deposit.getStatus()).isEqualTo(SavingsDepositStatus.MATURED);
+        verify(txRepo, times(1)).save(any(SavingsTransaction.class));
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,8 +78,13 @@ services:
     environment:
       ADMINER_DEFAULT_SERVER: db
       ADMINER_DESIGN: pepa-linha
+    # Adminer host port je env-driven (default 9001). Na Windows-u Hyper-V/WinNAT
+    # cesto rezervise 8568-9167 opseg (Bug 12.05.2026: "ports are not available...
+    # access permissions"). Default je 9001 jer to ima u CLAUDE.md istoriji,
+    # ali svako moze override-ovati preko env var-a (npr. ADMINER_HOST_PORT=9200
+    # za port iznad Hyper-V opsega).
     ports:
-      - "9001:8080"
+      - "${ADMINER_HOST_PORT:-9001}:8080"
 
   # Spring Boot backend
   backend:

--- a/seed.sql
+++ b/seed.sql
@@ -2683,53 +2683,53 @@ SELECT setval('currencies_id_seq', (SELECT COALESCE(MAX(id), 1) FROM currencies)
 -- CAD: 1.5-3.0%, AUD: 1.75-3.25%, JPY: 0.5-2.5%
 
 INSERT INTO savings_interest_rates (currency_id, term_months, annual_rate, active, effective_from, created_at) VALUES
-  ((SELECT id FROM currencies WHERE code='RSD'),  3, 2.50, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='RSD'),  6, 3.00, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='RSD'), 12, 4.00, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='RSD'), 24, 4.50, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='RSD'), 36, 5.00, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='RSD'),  3, 2.50, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='RSD'),  6, 3.00, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='RSD'), 12, 4.00, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='RSD'), 24, 4.50, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='RSD'), 36, 5.00, 1, '2026-01-01', NOW()),
 
-  ((SELECT id FROM currencies WHERE code='EUR'),  3, 1.50, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='EUR'),  6, 2.00, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='EUR'), 12, 2.50, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='EUR'), 24, 3.00, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='EUR'), 36, 3.50, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='EUR'),  3, 1.50, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='EUR'),  6, 2.00, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='EUR'), 12, 2.50, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='EUR'), 24, 3.00, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='EUR'), 36, 3.50, 1, '2026-01-01', NOW()),
 
-  ((SELECT id FROM currencies WHERE code='USD'),  3, 2.00, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='USD'),  6, 2.50, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='USD'), 12, 3.00, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='USD'), 24, 3.50, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='USD'), 36, 4.00, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='USD'),  3, 2.00, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='USD'),  6, 2.50, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='USD'), 12, 3.00, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='USD'), 24, 3.50, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='USD'), 36, 4.00, 1, '2026-01-01', NOW()),
 
-  ((SELECT id FROM currencies WHERE code='CHF'),  3, 1.00, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='CHF'),  6, 1.25, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='CHF'), 12, 1.50, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='CHF'), 24, 1.75, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='CHF'), 36, 2.00, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='CHF'),  3, 1.00, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='CHF'),  6, 1.25, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='CHF'), 12, 1.50, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='CHF'), 24, 1.75, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='CHF'), 36, 2.00, 1, '2026-01-01', NOW()),
 
-  ((SELECT id FROM currencies WHERE code='GBP'),  3, 1.75, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='GBP'),  6, 2.00, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='GBP'), 12, 2.50, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='GBP'), 24, 3.00, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='GBP'), 36, 3.25, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='GBP'),  3, 1.75, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='GBP'),  6, 2.00, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='GBP'), 12, 2.50, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='GBP'), 24, 3.00, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='GBP'), 36, 3.25, 1, '2026-01-01', NOW()),
 
-  ((SELECT id FROM currencies WHERE code='CAD'),  3, 1.50, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='CAD'),  6, 1.75, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='CAD'), 12, 2.25, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='CAD'), 24, 2.75, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='CAD'), 36, 3.00, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='CAD'),  3, 1.50, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='CAD'),  6, 1.75, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='CAD'), 12, 2.25, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='CAD'), 24, 2.75, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='CAD'), 36, 3.00, 1, '2026-01-01', NOW()),
 
-  ((SELECT id FROM currencies WHERE code='AUD'),  3, 1.75, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='AUD'),  6, 2.00, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='AUD'), 12, 2.50, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='AUD'), 24, 3.00, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='AUD'), 36, 3.25, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='AUD'),  3, 1.75, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='AUD'),  6, 2.00, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='AUD'), 12, 2.50, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='AUD'), 24, 3.00, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='AUD'), 36, 3.25, 1, '2026-01-01', NOW()),
 
-  ((SELECT id FROM currencies WHERE code='JPY'),  3, 0.50, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='JPY'),  6, 1.00, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='JPY'), 12, 1.50, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='JPY'), 24, 2.00, true, '2026-01-01', NOW()),
-  ((SELECT id FROM currencies WHERE code='JPY'), 36, 2.50, true, '2026-01-01', NOW());
+  ((SELECT id FROM currencies WHERE code='JPY'),  3, 0.50, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='JPY'),  6, 1.00, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='JPY'), 12, 1.50, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='JPY'), 24, 2.00, 1, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='JPY'), 36, 2.50, 1, '2026-01-01', NOW());
 
 SELECT setval('savings_interest_rates_id_seq', (SELECT COALESCE(MAX(id), 1) FROM savings_interest_rates));
 
@@ -2749,12 +2749,12 @@ INSERT INTO savings_deposits (
    (SELECT id FROM accounts WHERE client_id=1 AND currency_id=(SELECT id FROM currencies WHERE code='RSD') AND status='ACTIVE' ORDER BY id LIMIT 1),
    200000.0000, (SELECT id FROM currencies WHERE code='RSD'), 12,
    4.00, '2026-03-12', '2027-03-12', '2026-06-12',
-   1333.3333, true, 'ACTIVE', 0, NOW(), NOW()),
+   1333.3333, 1, 'ACTIVE', 0, NOW(), NOW()),
   (2,
    (SELECT id FROM accounts WHERE client_id=2 AND currency_id=(SELECT id FROM currencies WHERE code='EUR') AND status='ACTIVE' ORDER BY id LIMIT 1),
    1000.0000, (SELECT id FROM currencies WHERE code='EUR'), 6,
    2.00, '2026-04-12', '2026-10-12', '2026-06-12',
-   1.6667, false, 'ACTIVE', 0, NOW(), NOW());
+   1.6667, 0, 'ACTIVE', 0, NOW(), NOW());
 
 SELECT setval('savings_deposits_id_seq', (SELECT COALESCE(MAX(id), 1) FROM savings_deposits));
 

--- a/seed.sql
+++ b/seed.sql
@@ -2673,3 +2673,104 @@ WHERE user_id = 1 AND user_role = 'CLIENT' AND listing_ticker = 'AAPL';
 
 SELECT setval('companies_id_seq', (SELECT COALESCE(MAX(id), 1) FROM companies));
 SELECT setval('currencies_id_seq', (SELECT COALESCE(MAX(id), 1) FROM currencies));
+
+-- ============================================================
+-- STEDNJA (Celina 2 nadogradnja) — kamatne stope + demo deposits
+-- ============================================================
+
+-- 8 valuta x 5 rokova = 40 stopa (RSD/EUR/USD/CHF/GBP/CAD/AUD/JPY x 3/6/12/24/36 meseci)
+-- RSD: 2.5-5.0%, EUR/USD: 1.5-4.0%, CHF: 1.0-2.0%, GBP: 1.75-3.25%,
+-- CAD: 1.5-3.0%, AUD: 1.75-3.25%, JPY: 0.5-2.5%
+
+INSERT INTO savings_interest_rates (currency_id, term_months, annual_rate, active, effective_from, created_at) VALUES
+  ((SELECT id FROM currencies WHERE code='RSD'),  3, 2.50, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='RSD'),  6, 3.00, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='RSD'), 12, 4.00, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='RSD'), 24, 4.50, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='RSD'), 36, 5.00, true, '2026-01-01', NOW()),
+
+  ((SELECT id FROM currencies WHERE code='EUR'),  3, 1.50, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='EUR'),  6, 2.00, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='EUR'), 12, 2.50, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='EUR'), 24, 3.00, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='EUR'), 36, 3.50, true, '2026-01-01', NOW()),
+
+  ((SELECT id FROM currencies WHERE code='USD'),  3, 2.00, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='USD'),  6, 2.50, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='USD'), 12, 3.00, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='USD'), 24, 3.50, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='USD'), 36, 4.00, true, '2026-01-01', NOW()),
+
+  ((SELECT id FROM currencies WHERE code='CHF'),  3, 1.00, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='CHF'),  6, 1.25, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='CHF'), 12, 1.50, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='CHF'), 24, 1.75, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='CHF'), 36, 2.00, true, '2026-01-01', NOW()),
+
+  ((SELECT id FROM currencies WHERE code='GBP'),  3, 1.75, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='GBP'),  6, 2.00, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='GBP'), 12, 2.50, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='GBP'), 24, 3.00, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='GBP'), 36, 3.25, true, '2026-01-01', NOW()),
+
+  ((SELECT id FROM currencies WHERE code='CAD'),  3, 1.50, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='CAD'),  6, 1.75, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='CAD'), 12, 2.25, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='CAD'), 24, 2.75, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='CAD'), 36, 3.00, true, '2026-01-01', NOW()),
+
+  ((SELECT id FROM currencies WHERE code='AUD'),  3, 1.75, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='AUD'),  6, 2.00, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='AUD'), 12, 2.50, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='AUD'), 24, 3.00, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='AUD'), 36, 3.25, true, '2026-01-01', NOW()),
+
+  ((SELECT id FROM currencies WHERE code='JPY'),  3, 0.50, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='JPY'),  6, 1.00, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='JPY'), 12, 1.50, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='JPY'), 24, 2.00, true, '2026-01-01', NOW()),
+  ((SELECT id FROM currencies WHERE code='JPY'), 36, 2.50, true, '2026-01-01', NOW());
+
+SELECT setval('savings_interest_rates_id_seq', (SELECT COALESCE(MAX(id), 1) FROM savings_interest_rates));
+
+-- Demo deposit-i za seedovane klijente:
+-- Stefan (client_id=1): 200,000 RSD na 12 meseci, autoRenew=true, otvoren 2 meseca pre, vec 2 isplate kamate
+--   linked_account: prvi aktivni RSD racun Stefana (account_number=222000112345678911)
+-- Milica (client_id=2): 1,000 EUR na 6 meseci, autoRenew=false, otvoren 1 mesec pre, 1 isplata kamate
+--   linked_account: prvi aktivni EUR racun Milice (account_number=222000121345678923)
+-- Koristimo subquery umesto hard-coded account.id jer accounts tabela nema eksplicitne ID-eve u seed-u.
+
+INSERT INTO savings_deposits (
+    client_id, linked_account_id, principal_amount, currency_id, term_months,
+    annual_interest_rate, start_date, maturity_date, next_interest_payment_date,
+    total_interest_paid, auto_renew, status, version, created_at, updated_at
+) VALUES
+  (1,
+   (SELECT id FROM accounts WHERE client_id=1 AND currency_id=(SELECT id FROM currencies WHERE code='RSD') AND status='ACTIVE' ORDER BY id LIMIT 1),
+   200000.0000, (SELECT id FROM currencies WHERE code='RSD'), 12,
+   4.00, '2026-03-12', '2027-03-12', '2026-06-12',
+   1333.3333, true, 'ACTIVE', 0, NOW(), NOW()),
+  (2,
+   (SELECT id FROM accounts WHERE client_id=2 AND currency_id=(SELECT id FROM currencies WHERE code='EUR') AND status='ACTIVE' ORDER BY id LIMIT 1),
+   1000.0000, (SELECT id FROM currencies WHERE code='EUR'), 6,
+   2.00, '2026-04-12', '2026-10-12', '2026-06-12',
+   1.6667, false, 'ACTIVE', 0, NOW(), NOW());
+
+SELECT setval('savings_deposits_id_seq', (SELECT COALESCE(MAX(id), 1) FROM savings_deposits));
+
+-- Istorija transakcija za demo deposit-e
+-- deposit_id=1 = Stefanov RSD deposit, deposit_id=2 = Milicin EUR deposit
+-- (Ovi ID-evi su sigurni jer su ovo prvi INSERT-i u savings_deposits tabelu)
+INSERT INTO savings_transactions (deposit_id, type, amount, currency_id, processed_date, description, created_at) VALUES
+  (1, 'OPEN', 200000.0000, (SELECT id FROM currencies WHERE code='RSD'),
+   '2026-03-12', 'Otvaranje depozita rok=12m stopa=4.00% p.a.', '2026-03-12 09:00:00'),
+  (1, 'INTEREST_PAYMENT', 666.6667, (SELECT id FROM currencies WHERE code='RSD'),
+   '2026-04-12', 'Mesecna kamata depozita #1', '2026-04-12 02:00:00'),
+  (1, 'INTEREST_PAYMENT', 666.6667, (SELECT id FROM currencies WHERE code='RSD'),
+   '2026-05-12', 'Mesecna kamata depozita #1', '2026-05-12 02:00:00'),
+  (2, 'OPEN', 1000.0000, (SELECT id FROM currencies WHERE code='EUR'),
+   '2026-04-12', 'Otvaranje depozita rok=6m stopa=2.00% p.a.', '2026-04-12 10:30:00'),
+  (2, 'INTEREST_PAYMENT', 1.6667, (SELECT id FROM currencies WHERE code='EUR'),
+   '2026-05-12', 'Mesecna kamata depozita #2', '2026-05-12 02:00:00');
+
+SELECT setval('savings_transactions_id_seq', (SELECT COALESCE(MAX(id), 1) FROM savings_transactions));


### PR DESCRIPTION
## Summary

Dva paralelna scope-a u jednoj grani (Luka odlucio da ide direktno na `feature/savings-deposit` posle 17 bug fix-eva):

### 1. Stedna knjizica (oroceni depozit) — 12.05.2026 jutro

Nov klijent feature: oroceni depozit (3/6/12/24/36 meseci), klijent samostalno otvara, glavnica zakljucana, mesecna kamata isplata na povezani racun, razrocenje sa 1% penala, per-depozit auto-renew toggle.

- **Entiteti**: `SavingsDeposit` (sa `@Version` optimistic lock), `SavingsInterestRate`, `SavingsTransaction`. Statusi: ACTIVE / MATURED / WITHDRAWN_EARLY / RENEWED.
- **Servisi**: `SavingsDepositService` (open + listMy + getDeposit + withdrawEarly), `SavingsScheduler` cron `0 0 2 * * *` (mesecne kamate + dospeca + auto-renewals), `SavingsInterestRateService`, `SavingsAdminService`.
- **REST**: 8 endpoint-a (`POST /savings/deposits`, `GET /savings/deposits/my`, etc. + 2 admin `POST /admin/savings/rates` + `GET /admin/savings/deposits`).
- **Testovi**: 33 BE testa PASS (SavingsCalculator 6 + Rate Service 8 + Scheduler 6 + Deposit Service 13).
- **Seed**: 35 kamatnih stopa + 2 demo deposita + 5 demo transakcija.

### 2. Bug fix runda manuelnog testiranja — 12.05.2026 vece + vece-2

17 bagova fix-ovano iz 3 xlsx tracker-a + ad-hoc Sc 9 Tim 1 + 3 follow-up screenshot-a.

**Auth (4)**: 400→401 za login fail (T1-001/002/005/012, novi `AuthenticationFailedException`), lockout SR lokalizacija (T1-017), lockout na 5. pokusaju (T1-015), activation token status endpoint (Sc 9).

**Employee (1)**: email read-only u edit (T1-009/T1-010, BE odbija promenu).

**Tax (1)**: tax_record_breakdowns sad ukljucuje samo realised events (spec §517) — 22 lazno-negativnih → 1 stvarno realised. Tim screenshot pokazao 22 sve negativne profite za listings sa SAMO buy-orderima.

**Seed (1)**: savings_interest_rates `true`/`false` → `1`/`0` (Hibernate preferred_boolean_jdbc_type=INTEGER).

**Docker (1)**: adminer port env-driven (`ADMINER_HOST_PORT` override za Hyper-V opseg 8568-9167).

9 false positives dokumentovani u CLAUDE.md sa razlogom (T1-006 Departman, T1-014 /home, T1-018/019, T1-016 SMTP, T4-002 PATCH, T4-006 3M, T2-004 format, T2-006 filteri).

## Test plan

- [x] `mvn test` → **2538/2538 PASS, 0 Failures, BUILD SUCCESS** sa JDK 25 + Spring Boot 4.0.6
- [x] BE compile no errors sa novim AuthenticationFailedException + ActivationTokenStatusDto + email read-only validacija + TaxService sign fix
- [x] Docker rebuild --no-cache + compose up + seed prosao bez ERROR-a sa boolean→integer fix-om (40 stopa + 2 deposita)
- [x] Live smoke: login 200, pogresna lozinka 401, lockout 5. pokusaja, activation token status, email change reject, tax_record_breakdowns 22→1 redova, adminer http://localhost:9200 200