### PR TITLE
Notification triggers and order filtering

### DIFF
--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/card/service/implementation/CardServiceImpl.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/card/service/implementation/CardServiceImpl.java
@@ -20,7 +20,9 @@ import rs.raf.banka2_bek.card.repository.CardRepository;
 import rs.raf.banka2_bek.card.service.CardService;
 import rs.raf.banka2_bek.client.model.Client;
 import rs.raf.banka2_bek.client.repository.ClientRepository;
+import rs.raf.banka2_bek.notification.model.NotificationType;
 import rs.raf.banka2_bek.notification.service.MailSenderService;
+import rs.raf.banka2_bek.notification.service.NotificationService;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -45,6 +47,7 @@ public class CardServiceImpl implements CardService {
     private final AccountRepository accountRepository;
     private final ClientRepository clientRepository;
     private final MailSenderService mailSenderService;
+    private final NotificationService notificationService;
 
     @Override
     @Transactional
@@ -159,6 +162,22 @@ public class CardServiceImpl implements CardService {
             log.warn("Failed to send card notification email", e);
         }
 
+        if (card.getClient() != null) {
+            try {
+                notificationService.notify(
+                        card.getClient().getId(),
+                        "CLIENT",
+                        NotificationType.CARD_BLOCKED,
+                        "Kartica blokirana",
+                        "Vaša kartica je blokirana.",
+                        "CARD",
+                        card.getId()
+                );
+            } catch (Exception e) {
+                log.warn("Failed to send card blocked notification: {}", e.getMessage());
+            }
+        }
+
         return response;
     }
 
@@ -180,6 +199,22 @@ public class CardServiceImpl implements CardService {
                     card.getClient().getEmail(), last4);
         } catch (Exception e) {
             log.warn("Failed to send card notification email", e);
+        }
+
+        if (card.getClient() != null) {
+            try {
+                notificationService.notify(
+                        card.getClient().getId(),
+                        "CLIENT",
+                        NotificationType.CARD_UNBLOCKED,
+                        "Kartica odblokirana",
+                        "Vaša kartica je uspešno odblokirana.",
+                        "CARD",
+                        card.getId()
+                );
+            } catch (Exception e) {
+                log.warn("Failed to send card unblocked notification: {}", e.getMessage());
+            }
         }
 
         return response;
@@ -209,7 +244,25 @@ public class CardServiceImpl implements CardService {
             throw new RuntimeException("Ne moze se menjati limit deaktivirane kartice");
         }
         card.setCardLimit(newLimit);
-        return toMaskedResponse(cardRepository.save(card));
+        CardResponseDto limitResponse = toMaskedResponse(cardRepository.save(card));
+
+        if (card.getClient() != null) {
+            try {
+                notificationService.notify(
+                        card.getClient().getId(),
+                        "CLIENT",
+                        NotificationType.LIMIT_CHANGE,
+                        "Limit kartice promenjen",
+                        "Limit vaše kartice je uspešno promenjen na " + newLimit + ".",
+                        "CARD",
+                        card.getId()
+                );
+            } catch (Exception e) {
+                log.warn("Failed to send card limit change notification: {}", e.getMessage());
+            }
+        }
+
+        return limitResponse;
     }
 
     // --- helpers ---

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/loan/service/implementation/LoanServiceImpl.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/loan/service/implementation/LoanServiceImpl.java
@@ -18,7 +18,9 @@ import rs.raf.banka2_bek.loan.service.LoanService;
 import rs.raf.banka2_bek.loan.repository.LoanInstallmentRepository;
 import rs.raf.banka2_bek.loan.repository.LoanRepository;
 import rs.raf.banka2_bek.loan.repository.LoanRequestRepository;
+import rs.raf.banka2_bek.notification.model.NotificationType;
 import rs.raf.banka2_bek.notification.service.MailSenderService;
+import rs.raf.banka2_bek.notification.service.NotificationService;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
@@ -52,6 +54,8 @@ public class LoanServiceImpl implements LoanService {
     private final MailSenderService mailSenderService;
     private final String bankRegistrationNumber;
 
+    private final NotificationService notificationService;
+
     public LoanServiceImpl(LoanRequestRepository loanRequestRepository,
                            LoanRepository loanRepository,
                            LoanInstallmentRepository installmentRepository,
@@ -59,7 +63,8 @@ public class LoanServiceImpl implements LoanService {
                            ClientRepository clientRepository,
                            CurrencyRepository currencyRepository,
                            MailSenderService mailSenderService,
-                           @Value("${bank.registration-number}") String bankRegistrationNumber) {
+                           @Value("${bank.registration-number}") String bankRegistrationNumber,
+                           NotificationService notificationService) {
         this.loanRequestRepository = loanRequestRepository;
         this.loanRepository = loanRepository;
         this.installmentRepository = installmentRepository;
@@ -67,7 +72,8 @@ public class LoanServiceImpl implements LoanService {
         this.clientRepository = clientRepository;
         this.currencyRepository = currencyRepository;
         this.mailSenderService = mailSenderService;
-        this.bankRegistrationNumber = bankRegistrationNumber;
+        this.bankRegistrationNumber = bankRegistrationNumber;   
+        this.notificationService = notificationService;
     }
 
     @Override
@@ -116,6 +122,20 @@ public class LoanServiceImpl implements LoanService {
                     currency.getCode());
         } catch (Exception e) {
             log.warn("Failed to send loan request notification email", e);
+        }
+
+        try {
+            notificationService.notify(
+                    client.getId(),
+                    "CLIENT",
+                    NotificationType.LOAN_CREATED,
+                    "Zahtev za kredit primljen",
+                    "Vaš zahtev za kredit od " + loanRequest.getAmount() + " " + currency.getCode() + " je uspešno podnet i čeka na obradu.",
+                    "LOAN_REQUEST",
+                    loanRequest.getId()
+            );
+        } catch (Exception e) {
+            log.warn("Failed to send loan created notification: {}", e.getMessage());
         }
 
         return response;
@@ -237,6 +257,20 @@ public class LoanServiceImpl implements LoanService {
                     loan.getStartDate());
         } catch (Exception e) {
             log.warn("Failed to send loan approval notification email", e);
+        }
+
+        try {
+            notificationService.notify(
+                    request.getClient().getId(),
+                    "CLIENT",
+                    NotificationType.LOAN_APPROVED,
+                    "Kredit odobren",
+                    "Vaš kredit od " + loan.getAmount() + " " + loan.getCurrency().getCode() + " je odobren i sredstva su preneta na vaš račun.",
+                    "LOAN",
+                    loan.getId()
+            );
+        } catch (Exception e) {
+            log.warn("Failed to send loan approved notification: {}", e.getMessage());
         }
 
         return toLoanResponse(loan);

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/order/controller/OrderController.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/order/controller/OrderController.java
@@ -15,6 +15,7 @@ import rs.raf.banka2_bek.order.dto.OrderDto;
 import rs.raf.banka2_bek.order.service.OrderService;
 import rs.raf.banka2_bek.otp.service.OtpService;
 
+import java.time.LocalDate;
 import java.util.Map;
 
 // TODO [B4 - Filteri istorije ordera + B7 audit | Nosioci: Petar Poznanovic, Stasa Draskovic]
@@ -102,8 +103,12 @@ public class OrderController {
     @GetMapping("/my")
     public ResponseEntity<Page<OrderDto>> getMyOrders(
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "20") int size) {
-        return ResponseEntity.ok(orderService.getMyOrders(page, size));
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) LocalDate dateFrom,
+            @RequestParam(required = false) LocalDate dateTo,
+            @RequestParam(required = false) String listingType) {
+        return ResponseEntity.ok(orderService.getMyOrders(page, size, status, dateFrom, dateTo, listingType));
     }
 
     /**

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/order/repository/OrderRepository.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/order/repository/OrderRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,7 +16,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface OrderRepository extends JpaRepository<Order, Long> {
+public interface OrderRepository extends JpaRepository<Order, Long>, JpaSpecificationExecutor<Order> {
 
     Page<Order> findByStatus(OrderStatus status, Pageable pageable);
 

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/order/repository/OrderSpecification.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/order/repository/OrderSpecification.java
@@ -1,0 +1,43 @@
+package rs.raf.banka2_bek.order.repository;
+
+import org.springframework.data.jpa.domain.Specification;
+import rs.raf.banka2_bek.order.model.Order;
+import rs.raf.banka2_bek.order.model.OrderStatus;
+import rs.raf.banka2_bek.stock.model.ListingType;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class OrderSpecification {
+
+    private OrderSpecification() {}
+
+    public static Specification<Order> hasUserId(Long userId) {
+        return (root, query, cb) -> userId == null ? cb.conjunction()
+                : cb.equal(root.get("userId"), userId);
+    }
+
+    public static Specification<Order> hasStatus(OrderStatus status) {
+        return (root, query, cb) -> status == null ? cb.conjunction()
+                : cb.equal(root.get("status"), status);
+    }
+
+    public static Specification<Order> createdAfter(LocalDate dateFrom) {
+        return (root, query, cb) -> dateFrom == null ? cb.conjunction()
+                : cb.greaterThanOrEqualTo(root.get("createdAt"), dateFrom.atStartOfDay());
+    }
+
+    public static Specification<Order> createdBefore(LocalDate dateTo) {
+        return (root, query, cb) -> dateTo == null ? cb.conjunction()
+                : cb.lessThan(root.get("createdAt"), dateTo.plusDays(1).atStartOfDay());
+    }
+
+    public static Specification<Order> hasListingType(ListingType listingType) {
+        return (root, query, cb) -> {
+            if (listingType == null) {
+                return cb.conjunction();
+            }
+            return cb.equal(root.get("listing").get("listingType"), listingType);
+        };
+    }
+}

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/order/scheduler/OrderCleanupScheduler.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/order/scheduler/OrderCleanupScheduler.java
@@ -5,6 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import rs.raf.banka2_bek.notification.model.NotificationType;
+import rs.raf.banka2_bek.notification.service.NotificationService;
 import rs.raf.banka2_bek.order.model.Order;
 import rs.raf.banka2_bek.order.model.OrderStatus;
 import rs.raf.banka2_bek.order.repository.OrderRepository;
@@ -29,6 +31,7 @@ import java.util.List;
 public class OrderCleanupScheduler {
 
     private final OrderRepository orderRepository;
+    private final NotificationService notificationService;
 
     @Scheduled(cron = "0 0 1 * * *")
     @Transactional
@@ -54,6 +57,19 @@ public class OrderCleanupScheduler {
             log.info("Order {} (user={}, listing={}) declined - settlement {} passed",
                     order.getId(), order.getUserId(),
                     order.getListing().getTicker(), settlement);
+            try {
+                notificationService.notify(
+                        order.getUserId(),
+                        order.getUserRole(),
+                        NotificationType.ORDER_CANCELLED,
+                        "Nalog automatski otkazan",
+                        "Vaš nalog za " + order.getListing().getTicker() + " je automatski otkazan jer je datum dospeća prošao.",
+                        "ORDER",
+                        order.getId()
+                );
+            } catch (Exception ex) {
+                log.warn("Failed to send order cancelled notification for order #{}: {}", order.getId(), ex.getMessage());
+            }
             declinedCount++;
         }
 

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/order/service/OrderExecutionService.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/order/service/OrderExecutionService.java
@@ -19,6 +19,8 @@ import rs.raf.banka2_bek.order.model.OrderType;
 import rs.raf.banka2_bek.order.repository.OrderRepository;
 import rs.raf.banka2_bek.portfolio.model.Portfolio;
 import rs.raf.banka2_bek.portfolio.repository.PortfolioRepository;
+import rs.raf.banka2_bek.notification.model.NotificationType;
+import rs.raf.banka2_bek.notification.service.NotificationService;
 import rs.raf.banka2_bek.stock.model.Listing;
 import rs.raf.banka2_bek.stock.model.ListingType;
 import rs.raf.banka2_bek.stock.repository.ListingRepository;
@@ -71,6 +73,7 @@ public class OrderExecutionService {
     private final FundReservationService fundReservationService;
     private final FundLiquidationService fundLiquidationService;
     private final ApplicationEventPublisher eventPublisher;
+    private final NotificationService notificationService;
 
     @Value("${bank.registration-number}")
     private String bankRegistrationNumber;
@@ -135,6 +138,19 @@ public class OrderExecutionService {
 
                     log.warn("Order #{} auto-declined: settlement date {} has passed",
                             order.getId(), order.getListing().getSettlementDate());
+                    try {
+                        notificationService.notify(
+                                order.getUserId(),
+                                order.getUserRole(),
+                                NotificationType.ORDER_CANCELLED,
+                                "Nalog otkazan",
+                                "Vaš nalog za " + order.getListing().getTicker() + " je automatski otkazan jer je datum dospeća prošao.",
+                                "ORDER",
+                                order.getId()
+                        );
+                    } catch (Exception ex) {
+                        log.warn("Failed to send order cancelled notification for order #{}: {}", order.getId(), ex.getMessage());
+                    }
                     continue;
                 }
 
@@ -335,6 +351,33 @@ public class OrderExecutionService {
 
         if (justCompleted) {
             publishOrderCompleted(order);
+            try {
+                notificationService.notify(
+                        order.getUserId(),
+                        order.getUserRole(),
+                        NotificationType.ORDER_EXECUTED,
+                        "Nalog izvršen",
+                        "Vaš nalog za " + order.getListing().getTicker() + " je u potpunosti izvršen.",
+                        "ORDER",
+                        order.getId()
+                );
+            } catch (Exception ex) {
+                log.warn("Failed to send order executed notification for order #{}: {}", order.getId(), ex.getMessage());
+            }
+        } else {
+            try {
+                notificationService.notify(
+                        order.getUserId(),
+                        order.getUserRole(),
+                        NotificationType.ORDER_PARTIAL_FILL,
+                        "Nalog delimično izvršen",
+                        "Vaš nalog za " + order.getListing().getTicker() + " je delimično izvršen. Preostalo: " + order.getRemainingPortions() + " komada.",
+                        "ORDER",
+                        order.getId()
+                );
+            } catch (Exception ex) {
+                log.warn("Failed to send order partial fill notification for order #{}: {}", order.getId(), ex.getMessage());
+            }
         }
     }
 

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/order/service/OrderService.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/order/service/OrderService.java
@@ -4,6 +4,8 @@ import org.springframework.data.domain.Page;
 import rs.raf.banka2_bek.order.dto.CreateOrderDto;
 import rs.raf.banka2_bek.order.dto.OrderDto;
 
+import java.time.LocalDate;
+
 public interface OrderService {
 
     /**
@@ -54,9 +56,16 @@ public interface OrderService {
     Page<OrderDto> getAllOrders(String status, int page, int size);
 
     /**
-     * Pregled ordera jednog korisnika (za korisnika).
+     * Pregled ordera jednog korisnika (za korisnika) sa opcionim filterima.
+     *
+     * @param page       nula-bazirani broj stranice
+     * @param size       velicina stranice
+     * @param status     opcionalni filter po statusu (PENDING, APPROVED, DECLINED, DONE)
+     * @param dateFrom   opcionalni filter — orderi kreirani posle ovog datuma (ukljucivo)
+     * @param dateTo     opcionalni filter — orderi kreirani pre ovog datuma (ukljucivo)
+     * @param listingType opcionalni filter po tipu hartije (STOCK, FUTURES, FOREX)
      */
-    Page<OrderDto> getMyOrders(int page, int size);
+    Page<OrderDto> getMyOrders(int page, int size, String status, LocalDate dateFrom, LocalDate dateTo, String listingType);
 
     /**
      * Detalji jednog ordera.

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/order/service/implementation/OrderServiceImpl.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/order/service/implementation/OrderServiceImpl.java
@@ -43,10 +43,16 @@ import org.springframework.security.access.AccessDeniedException;
 import rs.raf.banka2_bek.portfolio.model.Portfolio;
 import rs.raf.banka2_bek.portfolio.repository.PortfolioRepository;
 import rs.raf.banka2_bek.stock.model.Listing;
+import rs.raf.banka2_bek.stock.model.ListingType;
 import rs.raf.banka2_bek.stock.repository.ListingRepository;
 import rs.raf.banka2_bek.stock.util.ListingCurrencyResolver;
+import rs.raf.banka2_bek.notification.model.NotificationType;
+import rs.raf.banka2_bek.notification.service.NotificationService;
+import org.springframework.data.jpa.domain.Specification;
+import rs.raf.banka2_bek.order.repository.OrderSpecification;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -93,6 +99,7 @@ public class OrderServiceImpl implements OrderService {
     private final CurrencyConversionService currencyConversionService;
     private final PortfolioRepository portfolioRepository;
     private final InvestmentFundRepository investmentFundRepository;
+    private final NotificationService notificationService;
 
     @Override
     @Transactional
@@ -286,6 +293,23 @@ public class OrderServiceImpl implements OrderService {
 
         // Step 12: Execution handled by OrderScheduler cron job
 
+        if (savedOrder.getStatus() == OrderStatus.PENDING) {
+            try {
+                notificationService.notify(
+                        savedOrder.getUserId(),
+                        savedOrder.getUserRole(),
+                        NotificationType.ORDER_PENDING,
+                        "Nalog čeka odobrenje",
+                        "Vaš nalog za " + savedOrder.getListing().getTicker() + " je kreiran i čeka odobrenje supervizora.",
+                        "ORDER",
+                        savedOrder.getId()
+                );
+            } catch (Exception e) {
+                org.slf4j.LoggerFactory.getLogger(OrderServiceImpl.class)
+                        .warn("Failed to send order pending notification: {}", e.getMessage());
+            }
+        }
+
         return toDtoWithUserName(savedOrder);
     }
 
@@ -453,6 +477,21 @@ public class OrderServiceImpl implements OrderService {
             });
         }
 
+        try {
+            notificationService.notify(
+                    saved.getUserId(),
+                    saved.getUserRole(),
+                    NotificationType.ORDER_APPROVED,
+                    "Nalog odobren",
+                    "Vaš nalog za " + saved.getListing().getTicker() + " je odobren i biće izvršen.",
+                    "ORDER",
+                    saved.getId()
+            );
+        } catch (Exception e) {
+            org.slf4j.LoggerFactory.getLogger(OrderServiceImpl.class)
+                    .warn("Failed to send order approved notification: {}", e.getMessage());
+        }
+
         return toDtoWithUserName(saved);
     }
 
@@ -500,6 +539,22 @@ public class OrderServiceImpl implements OrderService {
         order.setLastModification(LocalDateTime.now());
 
         Order saved = orderRepository.save(order);
+
+        try {
+            notificationService.notify(
+                    saved.getUserId(),
+                    saved.getUserRole(),
+                    NotificationType.ORDER_DECLINED,
+                    "Nalog odbijen",
+                    "Vaš nalog za " + (saved.getListing() != null ? saved.getListing().getTicker() : "") + " je odbijen.",
+                    "ORDER",
+                    saved.getId()
+            );
+        } catch (Exception e) {
+            org.slf4j.LoggerFactory.getLogger(OrderServiceImpl.class)
+                    .warn("Failed to send order declined notification: {}", e.getMessage());
+        }
+
         return toDtoWithUserName(saved);
     }
 
@@ -610,18 +665,44 @@ public class OrderServiceImpl implements OrderService {
     }
 
     @Override
-    public Page<OrderDto> getMyOrders(int page, int size) {
+    public Page<OrderDto> getMyOrders(int page, int size, String status, LocalDate dateFrom, LocalDate dateTo, String listingType) {
         String email = SecurityContextHolder.getContext().getAuthentication().getName();
         PageRequest pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
 
+        Long userId;
         Optional<Client> clientOpt = clientRepository.findByEmail(email);
         if (clientOpt.isPresent()) {
-            return orderRepository.findByUserId(clientOpt.get().getId(), pageable).map(this::toDtoWithUserName);
+            userId = clientOpt.get().getId();
+        } else {
+            Employee employee = employeeRepository.findByEmail(email)
+                    .orElseThrow(() -> new EntityNotFoundException("User not found"));
+            userId = employee.getId();
         }
 
-        Employee employee = employeeRepository.findByEmail(email)
-                .orElseThrow(() -> new EntityNotFoundException("User not found"));
-        return orderRepository.findByUserId(employee.getId(), pageable).map(this::toDtoWithUserName);
+        OrderStatus parsedStatus = null;
+        if (status != null && !status.isBlank() && !"ALL".equalsIgnoreCase(status)) {
+            try {
+                parsedStatus = OrderStatus.valueOf(status.toUpperCase());
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
+
+        ListingType parsedListingType = null;
+        if (listingType != null && !listingType.isBlank()) {
+            try {
+                parsedListingType = ListingType.valueOf(listingType.toUpperCase());
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
+
+        Specification<Order> spec = Specification
+                .where(OrderSpecification.hasUserId(userId))
+                .and(OrderSpecification.hasStatus(parsedStatus))
+                .and(OrderSpecification.createdAfter(dateFrom))
+                .and(OrderSpecification.createdBefore(dateTo))
+                .and(OrderSpecification.hasListingType(parsedListingType));
+
+        return orderRepository.findAll(spec, pageable).map(this::toDtoWithUserName);
     }
     @Override
     public OrderDto getOrderById(Long orderId) {

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/otc/repository/OtcContractRepository.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/otc/repository/OtcContractRepository.java
@@ -43,4 +43,8 @@ public interface OtcContractRepository extends JpaRepository<OtcContract, Long> 
     @Query("SELECT c FROM OtcContract c WHERE c.status = rs.raf.banka2_bek.otc.model.OtcContractStatus.ACTIVE " +
            "AND c.settlementDate < :today")
     List<OtcContract> findExpiredActive(@Param("today") LocalDate today);
+
+    @Query("SELECT c FROM OtcContract c WHERE c.status = rs.raf.banka2_bek.otc.model.OtcContractStatus.ACTIVE " +
+           "AND c.settlementDate = :targetDate")
+    List<OtcContract> findActiveExpiringOn(@Param("targetDate") LocalDate targetDate);
 }

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/otc/scheduler/OtcContractExpiryScheduler.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/otc/scheduler/OtcContractExpiryScheduler.java
@@ -4,11 +4,20 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import rs.raf.banka2_bek.notification.model.NotificationType;
+import rs.raf.banka2_bek.notification.service.NotificationService;
+import rs.raf.banka2_bek.otc.model.OtcContract;
+import rs.raf.banka2_bek.otc.repository.OtcContractRepository;
 import rs.raf.banka2_bek.otc.service.OtcService;
+
+import java.time.LocalDate;
+import java.util.List;
 
 /**
  * Dnevno markiranje OTC ugovora kojima je prosao settlementDate kao EXPIRED.
  * Time se prodavcima oslobadja publicQuantity za nove ponude.
+ *
+ * Takodje salje notifikacije 3 dana pre isteka (B4 zahtev).
  */
 @Slf4j
 @Component
@@ -16,12 +25,63 @@ import rs.raf.banka2_bek.otc.service.OtcService;
 public class OtcContractExpiryScheduler {
 
     private final OtcService otcService;
+    private final OtcContractRepository otcContractRepository;
+    private final NotificationService notificationService;
+
+    private static final int EXPIRY_NOTIFICATION_DAYS = 3;
 
     @Scheduled(cron = "0 5 1 * * *")
     public void expireContracts() {
         int count = otcService.expireSettledContracts();
         if (count > 0) {
             log.info("OTC: {} ugovora istekao i markiran EXPIRED", count);
+        }
+    }
+
+    @Scheduled(cron = "0 10 1 * * *")
+    public void notifyExpiringContracts() {
+        LocalDate targetDate = LocalDate.now().plusDays(EXPIRY_NOTIFICATION_DAYS);
+        List<OtcContract> expiring = otcContractRepository.findActiveExpiringOn(targetDate);
+
+        for (OtcContract contract : expiring) {
+            try {
+                notificationService.notify(
+                        contract.getBuyerId(),
+                        contract.getBuyerRole(),
+                        NotificationType.OTC_CONTRACT_EXPIRING,
+                        "Opcioni ugovor uskoro ističe",
+                        "Vaš opcioni ugovor za " + contract.getListing().getTicker()
+                                + " ističe za " + EXPIRY_NOTIFICATION_DAYS + " dana ("
+                                + contract.getSettlementDate() + ").",
+                        "OTC_CONTRACT",
+                        contract.getId()
+                );
+            } catch (Exception e) {
+                log.warn("Failed to send OTC expiry notification to buyer for contract #{}: {}",
+                        contract.getId(), e.getMessage());
+            }
+
+            try {
+                notificationService.notify(
+                        contract.getSellerId(),
+                        contract.getSellerRole(),
+                        NotificationType.OTC_CONTRACT_EXPIRING,
+                        "Opcioni ugovor uskoro ističe",
+                        "Opcioni ugovor za " + contract.getListing().getTicker()
+                                + " ističe za " + EXPIRY_NOTIFICATION_DAYS + " dana ("
+                                + contract.getSettlementDate() + ").",
+                        "OTC_CONTRACT",
+                        contract.getId()
+                );
+            } catch (Exception e) {
+                log.warn("Failed to send OTC expiry notification to seller for contract #{}: {}",
+                        contract.getId(), e.getMessage());
+            }
+        }
+
+        if (!expiring.isEmpty()) {
+            log.info("OTC: Poslate notifikacije o isteku za {} ugovora koji isticu za {} dana",
+                    expiring.size(), EXPIRY_NOTIFICATION_DAYS);
         }
     }
 }

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/otc/service/OtcService.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/otc/service/OtcService.java
@@ -31,6 +31,8 @@ import rs.raf.banka2_bek.otc.repository.OtcContractRepository;
 import rs.raf.banka2_bek.otc.repository.OtcOfferRepository;
 import rs.raf.banka2_bek.portfolio.model.Portfolio;
 import rs.raf.banka2_bek.portfolio.repository.PortfolioRepository;
+import rs.raf.banka2_bek.notification.model.NotificationType;
+import rs.raf.banka2_bek.notification.service.NotificationService;
 import rs.raf.banka2_bek.stock.model.Listing;
 import rs.raf.banka2_bek.stock.model.ListingType;
 import rs.raf.banka2_bek.stock.repository.ListingRepository;
@@ -88,6 +90,8 @@ public class OtcService {
     private final UserResolver userResolver;
     private final String bankRegistrationNumber;
 
+    private final NotificationService notificationService;
+
     public OtcService(OtcOfferRepository offerRepository,
                       OtcContractRepository contractRepository,
                       PortfolioRepository portfolioRepository,
@@ -95,7 +99,8 @@ public class OtcService {
                       AccountRepository accountRepository,
                       CurrencyConversionService currencyConversionService,
                       UserResolver userResolver,
-                      @Value("${bank.registration-number}") String bankRegistrationNumber) {
+                      @Value("${bank.registration-number}") String bankRegistrationNumber,
+                      NotificationService notificationService) {
         this.offerRepository = offerRepository;
         this.contractRepository = contractRepository;
         this.portfolioRepository = portfolioRepository;
@@ -104,6 +109,7 @@ public class OtcService {
         this.currencyConversionService = currencyConversionService;
         this.userResolver = userResolver;
         this.bankRegistrationNumber = bankRegistrationNumber;
+        this.notificationService = notificationService;
     }
 
     // ────────────────────────── Discovery ──────────────────────────
@@ -247,7 +253,25 @@ public class OtcService {
         offer.setWaitingOnUserId(me.userId().equals(offer.getBuyerId())
                 ? offer.getSellerId() : offer.getBuyerId());
 
-        return mapOffer(offerRepository.save(offer), me.userId());
+        OtcOffer savedOffer = offerRepository.save(offer);
+
+        try {
+            String otherRole = savedOffer.getWaitingOnUserId().equals(savedOffer.getBuyerId())
+                    ? savedOffer.getBuyerRole() : savedOffer.getSellerRole();
+            notificationService.notify(
+                    savedOffer.getWaitingOnUserId(),
+                    otherRole,
+                    NotificationType.OTC_COUNTER_OFFER,
+                    "Nova kontraponuda",
+                    "Primili ste novu kontraponudu za " + savedOffer.getListing().getTicker() + ".",
+                    "OTC_OFFER",
+                    savedOffer.getId()
+            );
+        } catch (Exception e) {
+            log.warn("Failed to send OTC counter offer notification: {}", e.getMessage());
+        }
+
+        return mapOffer(savedOffer, me.userId());
     }
 
     @Transactional
@@ -258,7 +282,27 @@ public class OtcService {
         offer.setStatus(OtcOfferStatus.DECLINED);
         offer.setLastModifiedById(me.userId());
         offer.setLastModifiedByName(resolveUserName(me.userId(), me.userRole()));
-        return mapOffer(offerRepository.save(offer), me.userId());
+        OtcOffer savedOffer = offerRepository.save(offer);
+
+        try {
+            Long otherPartyId = me.userId().equals(savedOffer.getBuyerId())
+                    ? savedOffer.getSellerId() : savedOffer.getBuyerId();
+            String otherRole = me.userId().equals(savedOffer.getBuyerId())
+                    ? savedOffer.getSellerRole() : savedOffer.getBuyerRole();
+            notificationService.notify(
+                    otherPartyId,
+                    otherRole,
+                    NotificationType.OTC_DECLINED,
+                    "Ponuda odbijena",
+                    "Vaša OTC ponuda za " + savedOffer.getListing().getTicker() + " je odbijena.",
+                    "OTC_OFFER",
+                    savedOffer.getId()
+            );
+        } catch (Exception e) {
+            log.warn("Failed to send OTC declined notification: {}", e.getMessage());
+        }
+
+        return mapOffer(savedOffer, me.userId());
     }
 
     /**
@@ -350,6 +394,25 @@ public class OtcService {
         offerRepository.save(offer);
 
         log.info("OTC offer #{} accepted by {} — contract #{} created", offer.getId(), me.userId(), contract.getId());
+
+        try {
+            Long otherPartyId = me.userId().equals(contract.getBuyerId())
+                    ? contract.getSellerId() : contract.getBuyerId();
+            String otherRole = me.userId().equals(contract.getBuyerId())
+                    ? contract.getSellerRole() : contract.getBuyerRole();
+            notificationService.notify(
+                    otherPartyId,
+                    otherRole,
+                    NotificationType.OTC_ACCEPTED,
+                    "Ponuda prihvaćena",
+                    "Vaša OTC ponuda za " + contract.getListing().getTicker() + " je prihvaćena i opcioni ugovor je sklopljen.",
+                    "OTC_CONTRACT",
+                    contract.getId()
+            );
+        } catch (Exception e) {
+            log.warn("Failed to send OTC accepted notification: {}", e.getMessage());
+        }
+
         return mapOffer(offer, me.userId());
     }
 

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/payment/service/implementation/PaymentServiceImpl.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/payment/service/implementation/PaymentServiceImpl.java
@@ -28,7 +28,9 @@ import rs.raf.banka2_bek.interbank.repository.InterbankTransactionRepository;
 import rs.raf.banka2_bek.interbank.service.BankRoutingService;
 import rs.raf.banka2_bek.interbank.service.InterbankPaymentAsyncService;
 import rs.raf.banka2_bek.interbank.service.TransactionExecutorService;
+import rs.raf.banka2_bek.notification.model.NotificationType;
 import rs.raf.banka2_bek.notification.service.MailSenderService;
+import rs.raf.banka2_bek.notification.service.NotificationService;
 import rs.raf.banka2_bek.payment.dto.CreatePaymentRequestDto;
 import rs.raf.banka2_bek.payment.dto.PaymentDirection;
 import rs.raf.banka2_bek.payment.dto.PaymentListItemDto;
@@ -77,6 +79,8 @@ public class PaymentServiceImpl implements PaymentService {
     private final InterbankPaymentAsyncService interbankPaymentAsyncService;
     private final InterbankTransactionRepository interbankTransactionRepository;
     private final String bankRegistrationNumber;
+    private final NotificationService notificationService;
+
     private static final int ORDER_NUMBER_MAX_RETRIES = 5;
     private static final BigDecimal COMMISSION_RATE = new BigDecimal("0.005"); // 0.5%
 
@@ -92,7 +96,8 @@ public class PaymentServiceImpl implements PaymentService {
                               TransactionExecutorService transactionExecutorService,
                               InterbankPaymentAsyncService interbankPaymentAsyncService,
                               InterbankTransactionRepository interbankTransactionRepository,
-                              @Value("${bank.registration-number}") String bankRegistrationNumber) {
+                              @Value("${bank.registration-number}") String bankRegistrationNumber,
+                              NotificationService notificationService) {
         this.paymentRepository = paymentRepository;
         this.paymentAccountRepository = paymentAccountRepository;
         this.accountRepository = accountRepository;
@@ -106,6 +111,7 @@ public class PaymentServiceImpl implements PaymentService {
         this.interbankPaymentAsyncService = interbankPaymentAsyncService;
         this.interbankTransactionRepository = interbankTransactionRepository;
         this.bankRegistrationNumber = bankRegistrationNumber;
+        this.notificationService = notificationService;
     }
 
     /**
@@ -267,6 +273,20 @@ public class PaymentServiceImpl implements PaymentService {
                     "COMPLETED");
         } catch (Exception e) {
             log.warn("Failed to send payment confirmation email: {}", e.getMessage());
+        }
+
+        try {
+            notificationService.notify(
+                    client.getId(),
+                    "CLIENT",
+                    NotificationType.PAYMENT,
+                    "Plaćanje izvršeno",
+                    "Vaše plaćanje od " + amount + " " + (fromAccount.getCurrency() != null ? fromAccount.getCurrency().getCode() : "") + " je uspešno izvršeno.",
+                    "PAYMENT",
+                    savedPayment.getId()
+            );
+        } catch (Exception e) {
+            log.warn("Failed to send payment notification: {}", e.getMessage());
         }
 
         return toResponse(savedPayment, client.getId(), null);

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/transfers/service/TransferService.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/transfers/service/TransferService.java
@@ -1,5 +1,6 @@
 package rs.raf.banka2_bek.transfers.service;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,6 +9,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import rs.raf.banka2_bek.account.model.Account;
 import rs.raf.banka2_bek.account.model.AccountStatus;
+import rs.raf.banka2_bek.notification.model.NotificationType;
+import rs.raf.banka2_bek.notification.service.NotificationService;
 import rs.raf.banka2_bek.client.model.Client;
 import rs.raf.banka2_bek.exchange.dto.CalculateExchangeResponseDto;
 import rs.raf.banka2_bek.payment.model.PaymentStatus;
@@ -33,6 +36,7 @@ import java.util.UUID;
 //       notifikacioniServis.posaljiUspesanTransferNotifikaciju(transfer);
 //   - executeFxTransfer() -> analogno posle FX konverzije i save.
 // Notifikacioni servis treba da bude injektovan kao zavisnost (@Autowired ili konstruktor).
+@Slf4j
 @Service
 public class TransferService {
 
@@ -41,17 +45,21 @@ public class TransferService {
     private final ExchangeService exchangeService;
     private final ClientRepository clientRepository;
 
+    private final NotificationService notificationService;
+
     @Value("${bank.registration-number}")
     private String bankRegistrationNumber;
 
     public TransferService(TransferRepository transferRepository,
                            AccountRepository accountRepository,
                            ExchangeService exchangeService,
-                           ClientRepository clientRepository) {
+                           ClientRepository clientRepository,
+                           NotificationService notificationService) {
         this.transferRepository = transferRepository;
         this.accountRepository = accountRepository;
         this.exchangeService = exchangeService;
         this.clientRepository = clientRepository;
+        this.notificationService = notificationService;
     }
 
     private TransferResponseDto mapToDto(Transfer transfer) {
@@ -135,6 +143,20 @@ public class TransferService {
         transfer.setCreatedBy(actor);
 
         transferRepository.save(transfer);
+
+        try {
+            notificationService.notify(
+                    actor.getId(),
+                    "CLIENT",
+                    NotificationType.TRANSFER,
+                    "Transfer izvršen",
+                    "Vaš interni transfer od " + request.getAmount() + " " + fromAccount.getCurrency().getCode() + " je uspešno izvršen.",
+                    "TRANSFER",
+                    transfer.getId()
+            );
+        } catch (Exception e) {
+            log.warn("Failed to send transfer notification: {}", e.getMessage());
+        }
 
         return mapToDto(transfer);
     }
@@ -239,6 +261,20 @@ public class TransferService {
         transfer.setCreatedBy(actor);
 
         transferRepository.save(transfer);
+
+        try {
+            notificationService.notify(
+                    actor.getId(),
+                    "CLIENT",
+                    NotificationType.TRANSFER,
+                    "FX transfer izvršen",
+                    "Vaš devizni transfer od " + request.getAmount() + " " + fromAccount.getCurrency().getCode() + " je uspešno izvršen.",
+                    "TRANSFER",
+                    transfer.getId()
+            );
+        } catch (Exception e) {
+            log.warn("Failed to send FX transfer notification: {}", e.getMessage());
+        }
 
         return mapToDto(transfer);
     }

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/loan/service/LoanServiceImplCoverageTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/loan/service/LoanServiceImplCoverageTest.java
@@ -21,6 +21,7 @@ import rs.raf.banka2_bek.loan.repository.LoanRepository;
 import rs.raf.banka2_bek.loan.repository.LoanRequestRepository;
 import rs.raf.banka2_bek.loan.service.implementation.LoanServiceImpl;
 import rs.raf.banka2_bek.notification.service.MailSenderService;
+import rs.raf.banka2_bek.notification.service.NotificationService;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -48,6 +49,7 @@ class LoanServiceImplCoverageTest {
     @Mock private ClientRepository clientRepository;
     @Mock private CurrencyRepository currencyRepository;
     @Mock private MailSenderService mailSenderService;
+    @Mock private NotificationService notificationService;
 
     private LoanServiceImpl loanService;
 
@@ -61,7 +63,7 @@ class LoanServiceImplCoverageTest {
         loanService = new LoanServiceImpl(
                 loanRequestRepository, loanRepository, installmentRepository,
                 accountRepository, clientRepository, currencyRepository,
-                mailSenderService, "22200022");
+                mailSenderService, "22200022", notificationService);
 
         rsd = new Currency();
         rsd.setId(8L);

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/loan/service/LoanServiceImplExtendedTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/loan/service/LoanServiceImplExtendedTest.java
@@ -29,6 +29,7 @@ import rs.raf.banka2_bek.loan.repository.LoanRepository;
 import rs.raf.banka2_bek.loan.repository.LoanRequestRepository;
 import rs.raf.banka2_bek.loan.service.implementation.LoanServiceImpl;
 import rs.raf.banka2_bek.notification.service.MailSenderService;
+import rs.raf.banka2_bek.notification.service.NotificationService;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
@@ -54,6 +55,7 @@ class LoanServiceImplExtendedTest {
     @Mock private ClientRepository clientRepository;
     @Mock private CurrencyRepository currencyRepository;
     @Mock private MailSenderService mailSenderService;
+    @Mock private NotificationService notificationService;
 
     private LoanServiceImpl loanService;
 
@@ -67,7 +69,7 @@ class LoanServiceImplExtendedTest {
         loanService = new LoanServiceImpl(
                 loanRequestRepository, loanRepository, installmentRepository,
                 accountRepository, clientRepository, currencyRepository,
-                mailSenderService, "22200022");
+                mailSenderService, "22200022", notificationService);
 
         rsd = new Currency();
         rsd.setId(8L);

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/loan/service/LoanServiceImplTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/loan/service/LoanServiceImplTest.java
@@ -26,6 +26,7 @@ import rs.raf.banka2_bek.loan.repository.LoanRepository;
 import rs.raf.banka2_bek.loan.repository.LoanRequestRepository;
 import rs.raf.banka2_bek.loan.service.implementation.LoanServiceImpl;
 import rs.raf.banka2_bek.notification.service.MailSenderService;
+import rs.raf.banka2_bek.notification.service.NotificationService;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -47,6 +48,7 @@ class LoanServiceImplTest {
     @Mock private ClientRepository clientRepository;
     @Mock private CurrencyRepository currencyRepository;
     @Mock private MailSenderService mailSenderService;
+    @Mock private NotificationService notificationService;
 
     private LoanServiceImpl loanService;
 
@@ -60,7 +62,7 @@ class LoanServiceImplTest {
         loanService = new LoanServiceImpl(
                 loanRequestRepository, loanRepository, installmentRepository,
                 accountRepository, clientRepository, currencyRepository,
-                mailSenderService, "22200022");
+                mailSenderService, "22200022", notificationService);
 
         rsd = new Currency();
         rsd.setId(8L);

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/order/controller/OrderControllerCoverageTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/order/controller/OrderControllerCoverageTest.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -132,7 +133,7 @@ class OrderControllerCoverageTest {
     @DisplayName("GET /orders/my - 200 sa paginated")
     void getMyOrders_success() throws Exception {
         Page<OrderDto> page = new PageImpl<>(List.of(sampleOrder(2L, "DONE")));
-        when(orderService.getMyOrders(0, 20)).thenReturn(page);
+        when(orderService.getMyOrders(eq(0), eq(20), isNull(), isNull(), isNull(), isNull())).thenReturn(page);
 
         mockMvc.perform(get("/orders/my"))
                 .andExpect(status().isOk())

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/order/scheduler/OrderCleanupSchedulerTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/order/scheduler/OrderCleanupSchedulerTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import rs.raf.banka2_bek.notification.model.NotificationType;
+import rs.raf.banka2_bek.notification.service.NotificationService;
 import rs.raf.banka2_bek.order.model.Order;
 import rs.raf.banka2_bek.order.model.OrderStatus;
 import rs.raf.banka2_bek.order.repository.OrderRepository;
@@ -20,6 +22,8 @@ public class OrderCleanupSchedulerTest {
 
     @Mock
     private OrderRepository orderRepository;
+    @Mock
+    private NotificationService notificationService;
 
     @InjectMocks
     private OrderCleanupScheduler orderCleanupScheduler;
@@ -75,5 +79,50 @@ public class OrderCleanupSchedulerTest {
         orderCleanupScheduler.cleanupExpiredOrders();
 
         verify(orderRepository, never()).save(any());
+    }
+
+    @Test
+    void cleanupExpiredOrders_shouldSendOrderCancelledNotification_whenOrderExpired() {
+        Order order = mock(Order.class);
+        Listing listing = mock(Listing.class);
+        when(listing.getSettlementDate()).thenReturn(LocalDate.now().minusDays(1));
+        when(listing.getTicker()).thenReturn("CLM24");
+        when(order.getListing()).thenReturn(listing);
+        when(order.getUserId()).thenReturn(7L);
+        when(order.getUserRole()).thenReturn("CLIENT");
+        when(order.getId()).thenReturn(99L);
+        when(orderRepository.findActiveNonDone()).thenReturn(List.of(order));
+
+        orderCleanupScheduler.cleanupExpiredOrders();
+
+        verify(notificationService).notify(
+                eq(7L),
+                eq("CLIENT"),
+                eq(NotificationType.ORDER_CANCELLED),
+                anyString(),
+                anyString(),
+                eq("ORDER"),
+                eq(99L)
+        );
+    }
+
+    @Test
+    void cleanupExpiredOrders_shouldContinueEvenWhenNotificationFails() {
+        Order order = mock(Order.class);
+        Listing listing = mock(Listing.class);
+        when(listing.getSettlementDate()).thenReturn(LocalDate.now().minusDays(1));
+        when(listing.getTicker()).thenReturn("CLM24");
+        when(order.getListing()).thenReturn(listing);
+        when(order.getUserId()).thenReturn(7L);
+        when(order.getUserRole()).thenReturn("CLIENT");
+        when(order.getId()).thenReturn(99L);
+        when(orderRepository.findActiveNonDone()).thenReturn(List.of(order));
+        doThrow(new RuntimeException("notification failure")).when(notificationService)
+                .notify(any(), any(), any(), any(), any(), any(), any());
+
+        orderCleanupScheduler.cleanupExpiredOrders();
+
+        verify(order).setStatus(OrderStatus.DECLINED);
+        verify(orderRepository).save(order);
     }
 }

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/order/service/GetMyOrdersFilteringTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/order/service/GetMyOrdersFilteringTest.java
@@ -1,0 +1,166 @@
+package rs.raf.banka2_bek.order.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import rs.raf.banka2_bek.account.repository.AccountRepository;
+import rs.raf.banka2_bek.actuary.repository.ActuaryInfoRepository;
+import rs.raf.banka2_bek.berza.service.ExchangeManagementService;
+import rs.raf.banka2_bek.client.model.Client;
+import rs.raf.banka2_bek.client.repository.ClientRepository;
+import rs.raf.banka2_bek.employee.model.Employee;
+import rs.raf.banka2_bek.employee.repository.EmployeeRepository;
+import rs.raf.banka2_bek.investmentfund.repository.InvestmentFundRepository;
+import rs.raf.banka2_bek.notification.service.NotificationService;
+import rs.raf.banka2_bek.order.dto.OrderDto;
+import rs.raf.banka2_bek.order.model.Order;
+import rs.raf.banka2_bek.order.model.OrderStatus;
+import rs.raf.banka2_bek.order.repository.OrderRepository;
+import rs.raf.banka2_bek.order.service.implementation.OrderServiceImpl;
+import rs.raf.banka2_bek.portfolio.repository.PortfolioRepository;
+import rs.raf.banka2_bek.stock.model.ListingType;
+import rs.raf.banka2_bek.stock.repository.ListingRepository;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@org.mockito.junit.jupiter.MockitoSettings(strictness = org.mockito.quality.Strictness.LENIENT)
+@DisplayName("OrderServiceImpl — getMyOrders filtering (B4)")
+class GetMyOrdersFilteringTest {
+
+    @Mock private OrderRepository orderRepository;
+    @Mock private ListingRepository listingRepository;
+    @Mock private ActuaryInfoRepository actuaryInfoRepository;
+    @Mock private ClientRepository clientRepository;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private OrderValidationService orderValidationService;
+    @Mock private ListingPriceService listingPriceService;
+    @Mock private FundsVerificationService fundsVerificationService;
+    @Mock private OrderStatusService orderStatusService;
+    @Mock private ExchangeManagementService exchangeManagementService;
+    @Mock private AccountRepository accountRepository;
+    @Mock private FundReservationService fundReservationService;
+    @Mock private BankTradingAccountResolver bankTradingAccountResolver;
+    @Mock private CurrencyConversionService currencyConversionService;
+    @Mock private PortfolioRepository portfolioRepository;
+    @Mock private InvestmentFundRepository investmentFundRepository;
+    @Mock private NotificationService notificationService;
+
+    @InjectMocks
+    private OrderServiceImpl orderService;
+
+    private Client client;
+    private Authentication auth;
+    private SecurityContext secCtx;
+
+    @BeforeEach
+    void setUp() {
+        client = new Client();
+        client.setId(42L);
+        client.setEmail("client@test.com");
+
+        auth = mock(Authentication.class);
+        when(auth.getName()).thenReturn("client@test.com");
+
+        secCtx = mock(SecurityContext.class);
+        when(secCtx.getAuthentication()).thenReturn(auth);
+        SecurityContextHolder.setContext(secCtx);
+
+        when(clientRepository.findByEmail("client@test.com")).thenReturn(Optional.of(client));
+        when(orderRepository.findAll(any(Specification.class), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(Collections.emptyList()));
+    }
+
+    @Test
+    @DisplayName("no filters — returns page via Specification")
+    void getMyOrders_noFilters_usesSpecification() {
+        Page<OrderDto> result = orderService.getMyOrders(0, 20, null, null, null, null);
+
+        assertNotNull(result);
+        verify(orderRepository).findAll(any(Specification.class), any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("status=PENDING — passes OrderStatus.PENDING to specification")
+    void getMyOrders_withStatusPending_callsRepository() {
+        Page<OrderDto> result = orderService.getMyOrders(0, 20, "PENDING", null, null, null);
+
+        assertNotNull(result);
+        verify(orderRepository).findAll(any(Specification.class), any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("status=ALL — treated as no status filter")
+    void getMyOrders_statusAll_treatedAsNoFilter() {
+        orderService.getMyOrders(0, 20, "ALL", null, null, null);
+
+        verify(orderRepository).findAll(any(Specification.class), any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("unknown status string — ignored gracefully")
+    void getMyOrders_unknownStatus_ignoredGracefully() {
+        assertDoesNotThrow(() -> orderService.getMyOrders(0, 10, "GARBAGE", null, null, null));
+    }
+
+    @Test
+    @DisplayName("dateFrom and dateTo are forwarded to specification")
+    void getMyOrders_withDateRange_callsRepository() {
+        LocalDate from = LocalDate.of(2025, 1, 1);
+        LocalDate to = LocalDate.of(2025, 6, 30);
+
+        orderService.getMyOrders(0, 20, null, from, to, null);
+
+        verify(orderRepository).findAll(any(Specification.class), any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("listingType=STOCK is forwarded to specification")
+    void getMyOrders_withListingTypeStock_callsRepository() {
+        orderService.getMyOrders(0, 20, null, null, null, "STOCK");
+
+        verify(orderRepository).findAll(any(Specification.class), any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("unknown listingType is ignored gracefully")
+    void getMyOrders_unknownListingType_ignoredGracefully() {
+        assertDoesNotThrow(() -> orderService.getMyOrders(0, 10, null, null, null, "OPTION"));
+    }
+
+    @Test
+    @DisplayName("resolves employee when client not found")
+    void getMyOrders_resolvesByEmployee_whenClientAbsent() {
+        Employee emp = new Employee();
+        emp.setId(77L);
+        emp.setEmail("emp@test.com");
+
+        when(auth.getName()).thenReturn("emp@test.com");
+        when(clientRepository.findByEmail("emp@test.com")).thenReturn(Optional.empty());
+        when(employeeRepository.findByEmail("emp@test.com")).thenReturn(Optional.of(emp));
+
+        orderService.getMyOrders(0, 20, null, null, null, null);
+
+        verify(orderRepository).findAll(any(Specification.class), any(Pageable.class));
+    }
+}

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/order/service/OrderServiceImplTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/order/service/OrderServiceImplTest.java
@@ -1205,15 +1205,12 @@ class OrderServiceImplTest {
         void getMyOrders_client_returnsOnlyHisOrders() {
             mockSecurityContext("client@test.com");
             when(clientRepository.findByEmail("client@test.com")).thenReturn(Optional.of(testClient));
-
-            PageRequest pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "createdAt"));
-            when(orderRepository.findByUserId(42L, pageable))
+            when(orderRepository.findAll(any(org.springframework.data.jpa.domain.Specification.class), any(org.springframework.data.domain.Pageable.class)))
                     .thenReturn(new PageImpl<>(List.of(makeOrder(1L, 42L))));
 
-            Page<OrderDto> result = orderService.getMyOrders(0, 20);
+            Page<OrderDto> result = orderService.getMyOrders(0, 20, null, null, null, null);
 
             assertEquals(1, result.getTotalElements());
-            verify(orderRepository).findByUserId(42L, pageable);
         }
 
         @Test
@@ -1222,12 +1219,10 @@ class OrderServiceImplTest {
             mockSecurityContext("agent@test.com");
             when(clientRepository.findByEmail("agent@test.com")).thenReturn(Optional.empty());
             when(employeeRepository.findByEmail("agent@test.com")).thenReturn(Optional.of(testEmployee));
-
-            PageRequest pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "createdAt"));
-            when(orderRepository.findByUserId(99L, pageable))
+            when(orderRepository.findAll(any(org.springframework.data.jpa.domain.Specification.class), any(org.springframework.data.domain.Pageable.class)))
                     .thenReturn(new PageImpl<>(List.of(makeOrder(5L, 99L))));
 
-            Page<OrderDto> result = orderService.getMyOrders(0, 20);
+            Page<OrderDto> result = orderService.getMyOrders(0, 20, null, null, null, null);
 
             assertEquals(1, result.getTotalElements());
         }
@@ -1239,7 +1234,7 @@ class OrderServiceImplTest {
             when(clientRepository.findByEmail("unknown@test.com")).thenReturn(Optional.empty());
             when(employeeRepository.findByEmail("unknown@test.com")).thenReturn(Optional.empty());
 
-            assertThrows(EntityNotFoundException.class, () -> orderService.getMyOrders(0, 20));
+            assertThrows(EntityNotFoundException.class, () -> orderService.getMyOrders(0, 20, null, null, null, null));
         }
     }
 

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/otc/scheduler/OtcContractExpirySchedulerTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/otc/scheduler/OtcContractExpirySchedulerTest.java
@@ -1,0 +1,133 @@
+package rs.raf.banka2_bek.otc.scheduler;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import rs.raf.banka2_bek.notification.model.NotificationType;
+import rs.raf.banka2_bek.notification.service.NotificationService;
+import rs.raf.banka2_bek.otc.model.OtcContract;
+import rs.raf.banka2_bek.otc.repository.OtcContractRepository;
+import rs.raf.banka2_bek.otc.service.OtcService;
+import rs.raf.banka2_bek.stock.model.Listing;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OtcContractExpirySchedulerTest {
+
+    @Mock private OtcService otcService;
+    @Mock private OtcContractRepository otcContractRepository;
+    @Mock private NotificationService notificationService;
+
+    @InjectMocks
+    private OtcContractExpiryScheduler scheduler;
+
+    // -----------------------------------------------------------------------
+    // expireContracts
+    // -----------------------------------------------------------------------
+
+    @Test
+    void expireContracts_delegatesToOtcService() {
+        when(otcService.expireSettledContracts()).thenReturn(0);
+
+        scheduler.expireContracts();
+
+        verify(otcService).expireSettledContracts();
+    }
+
+    @Test
+    void expireContracts_logsWhenContractsExpired() {
+        when(otcService.expireSettledContracts()).thenReturn(3);
+
+        scheduler.expireContracts();
+
+        verify(otcService).expireSettledContracts();
+    }
+
+    // -----------------------------------------------------------------------
+    // notifyExpiringContracts
+    // -----------------------------------------------------------------------
+
+    @Test
+    void notifyExpiringContracts_sendsNotificationToBothParties() {
+        Listing listing = mock(Listing.class);
+        when(listing.getTicker()).thenReturn("AAPL");
+
+        OtcContract contract = mock(OtcContract.class);
+        when(contract.getId()).thenReturn(1L);
+        when(contract.getBuyerId()).thenReturn(10L);
+        when(contract.getBuyerRole()).thenReturn("CLIENT");
+        when(contract.getSellerId()).thenReturn(20L);
+        when(contract.getSellerRole()).thenReturn("EMPLOYEE");
+        when(contract.getListing()).thenReturn(listing);
+        when(contract.getSettlementDate()).thenReturn(LocalDate.now().plusDays(3));
+
+        when(otcContractRepository.findActiveExpiringOn(any(LocalDate.class)))
+                .thenReturn(List.of(contract));
+
+        scheduler.notifyExpiringContracts();
+
+        verify(notificationService).notify(
+                eq(10L), eq("CLIENT"),
+                eq(NotificationType.OTC_CONTRACT_EXPIRING),
+                anyString(), anyString(), eq("OTC_CONTRACT"), eq(1L)
+        );
+        verify(notificationService).notify(
+                eq(20L), eq("EMPLOYEE"),
+                eq(NotificationType.OTC_CONTRACT_EXPIRING),
+                anyString(), anyString(), eq("OTC_CONTRACT"), eq(1L)
+        );
+    }
+
+    @Test
+    void notifyExpiringContracts_doesNothingWhenNoContractsExpiring() {
+        when(otcContractRepository.findActiveExpiringOn(any(LocalDate.class)))
+                .thenReturn(List.of());
+
+        scheduler.notifyExpiringContracts();
+
+        verify(notificationService, never()).notify(any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void notifyExpiringContracts_continuesIfBuyerNotificationFails() {
+        Listing listing = mock(Listing.class);
+        when(listing.getTicker()).thenReturn("MSFT");
+
+        OtcContract contract = mock(OtcContract.class);
+        when(contract.getId()).thenReturn(5L);
+        when(contract.getBuyerId()).thenReturn(10L);
+        when(contract.getBuyerRole()).thenReturn("CLIENT");
+        when(contract.getSellerId()).thenReturn(20L);
+        when(contract.getSellerRole()).thenReturn("EMPLOYEE");
+        when(contract.getListing()).thenReturn(listing);
+        when(contract.getSettlementDate()).thenReturn(LocalDate.now().plusDays(3));
+
+        when(otcContractRepository.findActiveExpiringOn(any())).thenReturn(List.of(contract));
+        doThrow(new RuntimeException("bus down"))
+                .when(notificationService).notify(eq(10L), any(), any(), any(), any(), any(), any());
+
+        scheduler.notifyExpiringContracts();
+
+        verify(notificationService).notify(
+                eq(20L), eq("EMPLOYEE"),
+                eq(NotificationType.OTC_CONTRACT_EXPIRING),
+                anyString(), anyString(), eq("OTC_CONTRACT"), eq(5L)
+        );
+    }
+
+    @Test
+    void notifyExpiringContracts_queriesCorrectDate() {
+        when(otcContractRepository.findActiveExpiringOn(any())).thenReturn(List.of());
+
+        scheduler.notifyExpiringContracts();
+
+        verify(otcContractRepository).findActiveExpiringOn(LocalDate.now().plusDays(3));
+    }
+}

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/payment/service/PaymentServiceBranchCoverageTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/payment/service/PaymentServiceBranchCoverageTest.java
@@ -27,6 +27,7 @@ import rs.raf.banka2_bek.interbank.service.BankRoutingService;
 import rs.raf.banka2_bek.interbank.service.TransactionExecutorService;
 import rs.raf.banka2_bek.interbank.service.InterbankPaymentAsyncService;
 import rs.raf.banka2_bek.interbank.repository.InterbankTransactionRepository;
+import rs.raf.banka2_bek.notification.service.NotificationService;
 import rs.raf.banka2_bek.payment.dto.CreatePaymentRequestDto;
 import rs.raf.banka2_bek.payment.model.PaymentCode;
 import rs.raf.banka2_bek.payment.dto.PaymentResponseDto;
@@ -70,6 +71,7 @@ class PaymentServiceBranchCoverageTest {
     @Mock private TransactionExecutorService transactionExecutorService;
     @Mock private InterbankPaymentAsyncService interbankPaymentAsyncService;
     @Mock private InterbankTransactionRepository interbankTransactionRepository;
+    @Mock private NotificationService notificationService;
 
     private PaymentServiceImpl paymentService;
 
@@ -81,7 +83,7 @@ class PaymentServiceBranchCoverageTest {
                 exchangeService, mailSenderService,
                 bankRoutingService, transactionExecutorService,
                 interbankPaymentAsyncService, interbankTransactionRepository,
-                "22200022");
+                "22200022", notificationService);
         when(bankRoutingService.isLocalAccount(any())).thenReturn(true);
     }
 

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/payment/service/PaymentServiceImplCoverageTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/payment/service/PaymentServiceImplCoverageTest.java
@@ -26,6 +26,7 @@ import rs.raf.banka2_bek.interbank.service.BankRoutingService;
 import rs.raf.banka2_bek.interbank.service.TransactionExecutorService;
 import rs.raf.banka2_bek.interbank.service.InterbankPaymentAsyncService;
 import rs.raf.banka2_bek.interbank.repository.InterbankTransactionRepository;
+import rs.raf.banka2_bek.notification.service.NotificationService;
 import rs.raf.banka2_bek.payment.dto.CreatePaymentRequestDto;
 import rs.raf.banka2_bek.payment.dto.PaymentResponseDto;
 import rs.raf.banka2_bek.payment.model.Payment;
@@ -67,6 +68,7 @@ class PaymentServiceImplCoverageTest {
     @Mock private TransactionExecutorService transactionExecutorService;
     @Mock private InterbankPaymentAsyncService interbankPaymentAsyncService;
     @Mock private InterbankTransactionRepository interbankTransactionRepository;
+    @Mock private NotificationService notificationService;
 
     private PaymentServiceImpl paymentService;
 
@@ -78,7 +80,7 @@ class PaymentServiceImplCoverageTest {
                 exchangeService, mailSenderService,
                 bankRoutingService, transactionExecutorService,
                 interbankPaymentAsyncService, interbankTransactionRepository,
-                "22200022");
+                "22200022", notificationService);
         lenient().when(bankRoutingService.isLocalAccount(any())).thenReturn(true);
     }
 

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/payment/service/PaymentServiceImplExtendedTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/payment/service/PaymentServiceImplExtendedTest.java
@@ -36,6 +36,7 @@ import rs.raf.banka2_bek.interbank.service.BankRoutingService;
 import rs.raf.banka2_bek.interbank.service.TransactionExecutorService;
 import rs.raf.banka2_bek.interbank.service.InterbankPaymentAsyncService;
 import rs.raf.banka2_bek.interbank.repository.InterbankTransactionRepository;
+import rs.raf.banka2_bek.notification.service.NotificationService;
 import rs.raf.banka2_bek.transaction.service.TransactionService;
 
 import org.springframework.dao.DataIntegrityViolationException;
@@ -71,6 +72,7 @@ class PaymentServiceImplExtendedTest {
     @Mock private TransactionExecutorService transactionExecutorService;
     @Mock private InterbankPaymentAsyncService interbankPaymentAsyncService;
     @Mock private InterbankTransactionRepository interbankTransactionRepository;
+    @Mock private NotificationService notificationService;
 
     private PaymentServiceImpl paymentService;
 
@@ -88,7 +90,7 @@ class PaymentServiceImplExtendedTest {
                 exchangeService, mailSenderService,
                 bankRoutingService, transactionExecutorService,
                 interbankPaymentAsyncService, interbankTransactionRepository,
-                "22200022");
+                "22200022", notificationService);
 
         lenient().when(bankRoutingService.isLocalAccount(any())).thenReturn(true);
 

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/payment/service/PaymentServiceImplTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/payment/service/PaymentServiceImplTest.java
@@ -32,6 +32,7 @@ import rs.raf.banka2_bek.interbank.service.BankRoutingService;
 import rs.raf.banka2_bek.interbank.service.TransactionExecutorService;
 import rs.raf.banka2_bek.interbank.service.InterbankPaymentAsyncService;
 import rs.raf.banka2_bek.interbank.repository.InterbankTransactionRepository;
+import rs.raf.banka2_bek.notification.service.NotificationService;
 import rs.raf.banka2_bek.transaction.dto.TransactionResponseDto;
 import rs.raf.banka2_bek.transaction.dto.TransactionType;
 import rs.raf.banka2_bek.transaction.service.TransactionService;
@@ -77,6 +78,8 @@ class PaymentServiceImplTest {
     private InterbankPaymentAsyncService interbankPaymentAsyncService;
     @Mock
     private InterbankTransactionRepository interbankTransactionRepository;
+    @Mock
+    private NotificationService notificationService;
 
     private PaymentServiceImpl paymentService;
 
@@ -94,7 +97,7 @@ class PaymentServiceImplTest {
                 exchangeService, mailSenderService,
                 bankRoutingService, transactionExecutorService,
                 interbankPaymentAsyncService, interbankTransactionRepository,
-                "22200022");
+                "22200022", notificationService);
 
         lenient().when(bankRoutingService.isLocalAccount(any())).thenReturn(true);
 

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/transfers/service/TransferServiceBranchTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/transfers/service/TransferServiceBranchTest.java
@@ -26,6 +26,7 @@ import rs.raf.banka2_bek.transfers.dto.TransferFxRequestDto;
 import rs.raf.banka2_bek.transfers.dto.TransferInternalRequestDto;
 import rs.raf.banka2_bek.transfers.dto.TransferResponseDto;
 import rs.raf.banka2_bek.transfers.repository.TransferRepository;
+import rs.raf.banka2_bek.notification.service.NotificationService;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -48,6 +49,7 @@ class TransferServiceBranchTest {
     @Mock private AccountRepository accountRepository;
     @Mock private ExchangeService exchangeService;
     @Mock private ClientRepository clientRepository;
+    @Mock private NotificationService notificationService;
 
     private TransferService transferService;
 
@@ -73,7 +75,7 @@ class TransferServiceBranchTest {
     void setUp() throws Exception {
         SecurityContextHolder.setStrategyName(SecurityContextHolder.MODE_GLOBAL);
         transferService = new TransferService(
-                transferRepository, accountRepository, exchangeService, clientRepository);
+                transferRepository, accountRepository, exchangeService, clientRepository, notificationService);
 
         java.lang.reflect.Field field = TransferService.class.getDeclaredField("bankRegistrationNumber");
         field.setAccessible(true);

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/transfers/service/TransferServiceCoverageTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/transfers/service/TransferServiceCoverageTest.java
@@ -23,6 +23,7 @@ import rs.raf.banka2_bek.transfers.dto.TransferFxRequestDto;
 import rs.raf.banka2_bek.transfers.dto.TransferResponseDto;
 import rs.raf.banka2_bek.transfers.model.Transfer;
 import rs.raf.banka2_bek.transfers.repository.TransferRepository;
+import rs.raf.banka2_bek.notification.service.NotificationService;
 
 import java.lang.reflect.Field;
 import java.math.BigDecimal;
@@ -49,6 +50,7 @@ class TransferServiceCoverageTest {
     @Mock private AccountRepository accountRepository;
     @Mock private ExchangeService exchangeService;
     @Mock private ClientRepository clientRepository;
+    @Mock private NotificationService notificationService;
 
     private TransferService transferService;
 
@@ -60,7 +62,7 @@ class TransferServiceCoverageTest {
         // iz integration testa) i Mockito strict stub puca jer code-under-test
         // poziva findByEmail sa neocekivanim argumentom.
         SecurityContextHolder.clearContext();
-        transferService = new TransferService(transferRepository, accountRepository, exchangeService, clientRepository);
+        transferService = new TransferService(transferRepository, accountRepository, exchangeService, clientRepository, notificationService);
         Field f = TransferService.class.getDeclaredField("bankRegistrationNumber");
         f.setAccessible(true);
         f.set(transferService, "22200022");

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/transfers/service/TransferServiceExtendedTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/transfers/service/TransferServiceExtendedTest.java
@@ -25,6 +25,7 @@ import rs.raf.banka2_bek.transfers.dto.TransferFxRequestDto;
 import rs.raf.banka2_bek.transfers.dto.TransferInternalRequestDto;
 import rs.raf.banka2_bek.transfers.dto.TransferResponseDto;
 import rs.raf.banka2_bek.transfers.repository.TransferRepository;
+import rs.raf.banka2_bek.notification.service.NotificationService;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -47,6 +48,7 @@ class TransferServiceExtendedTest {
     @Mock private AccountRepository accountRepository;
     @Mock private ExchangeService exchangeService;
     @Mock private ClientRepository clientRepository;
+    @Mock private NotificationService notificationService;
 
     private TransferService transferService;
 
@@ -71,7 +73,7 @@ class TransferServiceExtendedTest {
     void setUp() throws Exception {
         SecurityContextHolder.setStrategyName(SecurityContextHolder.MODE_GLOBAL);
         transferService = new TransferService(
-                transferRepository, accountRepository, exchangeService, clientRepository);
+                transferRepository, accountRepository, exchangeService, clientRepository, notificationService);
         java.lang.reflect.Field field = TransferService.class.getDeclaredField("bankRegistrationNumber");
         field.setAccessible(true);
         field.set(transferService, "22200022");

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/transfers/service/TransferServiceTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/transfers/service/TransferServiceTest.java
@@ -23,6 +23,7 @@ import rs.raf.banka2_bek.transfers.dto.TransferInternalRequestDto;
 import rs.raf.banka2_bek.transfers.dto.TransferResponseDto;
 import rs.raf.banka2_bek.account.repository.AccountRepository;
 import rs.raf.banka2_bek.transfers.repository.TransferRepository;
+import rs.raf.banka2_bek.notification.service.NotificationService;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -51,6 +52,9 @@ public class TransferServiceTest {
     @Mock
     private ClientRepository clientRepository;
 
+    @Mock
+    private NotificationService notificationService;
+
     private TransferService transferService;
 
     private Account fromAccount;
@@ -75,7 +79,7 @@ public class TransferServiceTest {
         SecurityContextHolder.setStrategyName(SecurityContextHolder.MODE_GLOBAL);
         transferService = new TransferService(
                 transferRepository, accountRepository, exchangeService,
-                clientRepository);
+                clientRepository, notificationService);
         java.lang.reflect.Field field = TransferService.class.getDeclaredField("bankRegistrationNumber");
         field.setAccessible(true);
         field.set(transferService, "22200022");


### PR DESCRIPTION
## Summary

Implementacija zadatka B4 — integracija notifikacionog sistema (B1) u poslovnu logiku i proširenje filtriranja ordera.

Notification triggers:

PaymentServiceImpl → PAYMENT notifikacija nakon uspešnog plaćanja
TransferService → TRANSFER notifikacija nakon internog i FX transfera
CardServiceImpl → CARD_BLOCKED, CARD_UNBLOCKED, LIMIT_CHANGE notifikacije
LoanServiceImpl → LOAN_CREATED, LOAN_APPROVED notifikacije
OrderServiceImpl → ORDER_PENDING, ORDER_APPROVED, ORDER_DECLINED notifikacije
OrderExecutionService → ORDER_EXECUTED, ORDER_PARTIAL_FILL, ORDER_CANCELLED notifikacije
OrderCleanupScheduler → ORDER_CANCELLED pri automatskom isteku ordera
OtcService → OTC_COUNTER_OFFER, OTC_DECLINED, OTC_ACCEPTED notifikacije
OtcContractExpiryScheduler → novi @Scheduled job koji šalje OTC_CONTRACT_EXPIRING notifikaciju kupcu i prodavcu 3 dana pre isteka ugovora
Order filtering (GET /orders/my):

Dodat OrderSpecification (JPA Specification) za dinamičke filtere
OrderRepository proširuje JpaSpecificationExecutor<Order>
Endpoint prima opcione parametre: status, dateFrom, dateTo, listingType
Bugfix:

Dodat @Slf4j na TransferService (nedostajalo, log promenljiva nije bila definisana)
Tests:

OtcContractExpirySchedulerTest — 4 nova testa
GetMyOrdersFilteringTest — 8 novih testova za sve kombinacije filtera
OrderCleanupSchedulerTest — 2 nova testa za notifikaciju + otpornost na pad
Ažurirani postojeći testovi (TransferService*, PaymentServiceImpl*, LoanServiceImpl*, OrderServiceImplTest, OrderControllerCoverageTest) da koriste nove konstruktore/potpise metoda
## Test plan


 mvn test -Dtest=OtcContractExpirySchedulerTest,GetMyOrdersFilteringTest,OrderCleanupSchedulerTest — svi prolaze

 Ručno testirati GET /orders/my?status=PENDING&listingType=STOCK&dateFrom=2025-01-01 putem Postman-a ili Swagger UI

 Verifikovati da notifikacije stignu u inbox nakon plaćanja, transfera, akcija sa karticom, kreditom, orderom i OTC ugovorom