### PR TITLE
Implementacija B11 - fund dividend handling

### DIFF
--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/dividend/service/DividendService.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/dividend/service/DividendService.java
@@ -2,9 +2,6 @@ package rs.raf.banka2_bek.dividend.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -20,6 +17,8 @@ import rs.raf.banka2_bek.auth.util.UserResolver;
 import rs.raf.banka2_bek.dividend.dto.DividendPayoutDto;
 import rs.raf.banka2_bek.dividend.model.DividendPayout;
 import rs.raf.banka2_bek.dividend.repository.DividendPayoutRepository;
+import rs.raf.banka2_bek.investmentfund.model.ClientFundTransaction;
+import rs.raf.banka2_bek.investmentfund.service.FundDividendService;
 import rs.raf.banka2_bek.order.service.CurrencyConversionService;
 import rs.raf.banka2_bek.portfolio.model.Portfolio;
 import rs.raf.banka2_bek.portfolio.repository.PortfolioRepository;
@@ -29,7 +28,6 @@ import rs.raf.banka2_bek.stock.repository.ListingRepository;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -110,6 +108,7 @@ public class DividendService {
     private final ListingRepository listingRepository;
     private final UserResolver userResolver;
     private final CurrencyConversionService currencyConversionService;
+    private final FundDividendService fundDividendService;
 
     @Value("${bank.registration-number:22200022}")
     private String bankRegistrationNumber;
@@ -181,8 +180,44 @@ public class DividendService {
         BigDecimal tax = isTaxExempt ? BigDecimal.ZERO : grossAmount.multiply(new BigDecimal("0.15")).setScale(4, RoundingMode.HALF_UP);
         BigDecimal netAmount = grossAmount.subtract(tax).setScale(4, RoundingMode.HALF_UP);
 
-        // Određivanje valute i računa
+        // Određivanje valute. Za fondove se B11 grana posebno obrađuje: sredstva se knjiže na račun fonda
+        // i dalje se obrađuju kroz FundDividendService (reinvestiranje ili raspodela klijentima).
         String currencyCode = listing.getBaseCurrency() != null ? listing.getBaseCurrency() : "USD"; // Fallback na USD ako nema valute
+
+        if ("FUND".equalsIgnoreCase(portfolio.getUserRole())) {
+            BigDecimal amountForFund = grossAmount;
+            if (!"RSD".equalsIgnoreCase(currencyCode)) {
+                amountForFund = currencyConversionService.convert(grossAmount, currencyCode, "RSD");
+            }
+
+            ClientFundTransaction fundTx = fundDividendService.creditDividendToFund(
+                    portfolio.getUserId(),
+                    portfolio.getListingId(),
+                    amountForFund);
+
+            DividendPayout payout = DividendPayout.builder()
+                    .ownerId(portfolio.getUserId())
+                    .ownerType(portfolio.getUserRole().toUpperCase())
+                    .stockListingId(portfolio.getListingId())
+                    .stockTicker(portfolio.getListingTicker())
+                    .quantity(portfolio.getQuantity())
+                    .priceOnDate(price)
+                    .dividendYieldRate(quarterlyYieldRate)
+                    .grossAmount(amountForFund)
+                    .tax(BigDecimal.ZERO)
+                    .netAmount(amountForFund)
+                    .creditedAccountId(fundTx.getSourceAccountId())
+                    .currencyCode("RSD")
+                    .paymentDate(paymentDate)
+                    .taxExempt(true)
+                    .build();
+
+            dividendPayoutRepository.save(payout);
+            log.info("B11: dividenda za ticker {} uplaćena fondu #{}, iznos={} RSD",
+                    portfolio.getListingTicker(), portfolio.getUserId(), amountForFund);
+            return;
+        }
+
         Account targetAccount = resolveTargetAccount(portfolio, currencyCode);
 
         // Ako je primenjen Fallback 2 (konverzija u RSD), moramo prebaciti neto iznos u RSD

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/investmentfund/model/ClientFundTransaction.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/investmentfund/model/ClientFundTransaction.java
@@ -39,7 +39,7 @@ public class ClientFundTransaction {
     private boolean inflow;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 16)
+    @Column(nullable = false, length = 32)
     private ClientFundTransactionStatus status;
 
     @Column(name = "created_at", nullable = false)

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/investmentfund/model/ClientFundTransactionStatus.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/investmentfund/model/ClientFundTransactionStatus.java
@@ -3,5 +3,17 @@ package rs.raf.banka2_bek.investmentfund.model;
 public enum ClientFundTransactionStatus {
     PENDING,
     COMPLETED,
-    FAILED
+    FAILED,
+
+    // B11 — dividenda je primljena na račun fonda, ali još nije obrađena
+    // kroz reinvestiranje ili raspodelu klijentima.
+    DIVIDEND_INFLOW,
+
+    // B11 — primljena dividenda je iskorišćena za kreiranje BUY ordera
+    // u ime investicionog fonda.
+    DIVIDEND_REINVESTED,
+
+    // B11 — primljena dividenda je raspodeljena klijentima proporcionalno
+    // njihovom udelu u fondu.
+    DIVIDEND_DISTRIBUTED
 }

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/investmentfund/repository/ClientFundTransactionRepository.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/investmentfund/repository/ClientFundTransactionRepository.java
@@ -13,5 +13,14 @@ public interface ClientFundTransactionRepository extends JpaRepository<ClientFun
     List<ClientFundTransaction> findByUserIdAndUserRoleOrderByCreatedAtDesc(Long userId, String userRole);
 
     List<ClientFundTransaction> findByStatus(ClientFundTransactionStatus status);
-    List<ClientFundTransaction> findByUserIdAndStatusOrderByCreatedAtAsc(Long userId, ClientFundTransactionStatus status);
+
+    List<ClientFundTransaction> findByFundIdAndStatusOrderByCreatedAtAsc(
+            Long fundId,
+            ClientFundTransactionStatus status
+    );
+
+    List<ClientFundTransaction> findByUserIdAndStatusOrderByCreatedAtAsc(
+            Long userId,
+            ClientFundTransactionStatus status
+    );
 }

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/investmentfund/service/FundDividendService.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/investmentfund/service/FundDividendService.java
@@ -1,70 +1,513 @@
 package rs.raf.banka2_bek.investmentfund.service;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import rs.raf.banka2_bek.account.model.Account;
+import rs.raf.banka2_bek.account.model.AccountStatus;
+import rs.raf.banka2_bek.account.repository.AccountRepository;
+import rs.raf.banka2_bek.auth.util.UserRole;
+import rs.raf.banka2_bek.investmentfund.model.ClientFundPosition;
+import rs.raf.banka2_bek.investmentfund.model.ClientFundTransaction;
+import rs.raf.banka2_bek.investmentfund.model.ClientFundTransactionStatus;
+import rs.raf.banka2_bek.investmentfund.model.InvestmentFund;
+import rs.raf.banka2_bek.investmentfund.repository.ClientFundPositionRepository;
+import rs.raf.banka2_bek.investmentfund.repository.ClientFundTransactionRepository;
+import rs.raf.banka2_bek.investmentfund.repository.InvestmentFundRepository;
+import rs.raf.banka2_bek.investmentfund.scheduler.FundValueSnapshotScheduler;
+import rs.raf.banka2_bek.order.exception.InsufficientFundsException;
+import rs.raf.banka2_bek.order.model.Order;
+import rs.raf.banka2_bek.order.model.OrderDirection;
+import rs.raf.banka2_bek.order.model.OrderStatus;
+import rs.raf.banka2_bek.order.model.OrderType;
+import rs.raf.banka2_bek.order.repository.OrderRepository;
+import rs.raf.banka2_bek.order.service.CurrencyConversionService;
+import rs.raf.banka2_bek.order.service.FundReservationService;
+import rs.raf.banka2_bek.stock.model.Listing;
+import rs.raf.banka2_bek.stock.repository.ListingRepository;
+import rs.raf.banka2_bek.stock.util.ListingCurrencyResolver;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
 
-// ============================================================
-// TODO [B11 - Dividende u investicionim fondovima | Nosilac: Brasanac]
-//
-// Servis koji obradjuje dividende primljene od akcija u vlasnistvu
-// investicionog fonda: biljezi prihod dividende u fond, sprovodi
-// reinvestiranje (automatska kupovina hartija) ili distribuciju
-// (isplata klijentima srazmerno udelima).
-//
-// IMPLEMENTIRATI:
-//
-//   - creditDividendToFund(Long fundId, Long listingId, BigDecimal totalDividendAmount)
-//       Kreira se B11 prihod dividende: ukupan iznos dividende (cena
-//       dividende x kolicina u fondu) kredituje se na cash racun fonda
-//       (AccountCategory.FUND_CASH ili ekvivalent). Belezi se u
-//       ClientFundTransaction tip DIVIDEND_INFLOW (novi enum red koji
-//       treba dodati u ClientFundTransactionStatus ili zasebni enum).
-//       Poziva se iz B9 mehanizma isplate dividendi kada je vlasnik
-//       portfolio pozicije fond (userRole == "FUND").
-//
-//   - reinvestDividends(Long fundId)
-//       Supervizor (ili scheduler) okida reinvestiranje nakupljenih
-//       dividendi. Ucitava neutrocene dividende fonda, formira MARKET
-//       BUY order za listing koji je generisao dividendu (ili
-//       konfigurisani default listing). Kolicina = floor(cash /
-//       currentPrice). Delegira egzekuciju kroz OrderService ili
-//       direktno kroz OrderRepository (pratiti obrazac iz
-//       FundLiquidationService). Ako cash nije dovoljan za ni jedan
-//       deo hartije, log.warn i izlaz. Oznaci dividendu kao REINVESTED.
-//
-//   - distributeDividendsToClients(Long fundId)
-//       Alternativa reinvestiranju: raspodjela cash dividende klijentima
-//       proporcionalno udelima (ClientFundPosition.units /
-//       InvestmentFund.totalUnits). Za svakog klijenta kredituje se
-//       odgovarajuci racun (Client.linkedAccount ili racun u valuti
-//       fonda). Kreira ClientFundTransaction po klijentu tip
-//       DIVIDEND_DISTRIBUTION. Poziv je idempotent - vec distribuirane
-//       dividende se preskacu. Cela operacija treba biti u jednoj
-//       @Transactional granici.
-//
-//   - listPendingDividends(Long fundId)
-//       Vraca listu svih ClientFundTransaction zapisa za dati fond
-//       sa statusom koji oznacava neobradjenu dividendu (tip
-//       DIVIDEND_INFLOW i status PENDING). Koristi se za FE pregled
-//       i kao ulaz za reinvest/distribute operacije.
-//
-//   - scheduledDividendProcessing()
-//       @Scheduled(cron = "0 30 2 * * *") metoda koja za svaki
-//       aktivan fond poziva reinvestDividends ili
-//       distributeDividendsToClients u zavisnosti od konfiguracionog
-//       flega fonda (InvestmentFund.dividendStrategy ili sl.).
-//       Hvata i loguje izuzetke po fondu da jedan fail ne blokira
-//       ostale (obrazac iz SavingsScheduler).
-//
-// Konvencija: pratiti paket `savings` kao sablon.
-// Spec: Zadaci_Backend.pdf, zadatak B11.
-// ============================================================
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class FundDividendService {
 
+    private static final String RSD = "RSD";
+    private static final int MONEY_SCALE = 4;
+
+    private final InvestmentFundRepository investmentFundRepository;
+    private final ClientFundTransactionRepository clientFundTransactionRepository;
+    private final ClientFundPositionRepository clientFundPositionRepository;
+    private final AccountRepository accountRepository;
+    private final ListingRepository listingRepository;
+    private final OrderRepository orderRepository;
+    private final FundReservationService fundReservationService;
+    private final CurrencyConversionService currencyConversionService;
+    private final FundValueSnapshotScheduler fundValueSnapshotScheduler;
+
+    @Transactional
+    public ClientFundTransaction creditDividendToFund(Long fundId, Long listingId, BigDecimal totalDividendAmount) {
+        if (fundId == null) {
+            throw new IllegalArgumentException("Fund id je obavezan za B11 dividendni priliv.");
+        }
+        if (listingId == null) {
+            throw new IllegalArgumentException("Listing id je obavezan za B11 dividendni priliv.");
+        }
+        if (totalDividendAmount == null || totalDividendAmount.signum() <= 0) {
+            throw new IllegalArgumentException("Iznos dividende mora biti pozitivan.");
+        }
+
+        InvestmentFund fund = getActiveFund(fundId);
+        Account fundAccount = getFundAccountForUpdate(fund);
+        BigDecimal amount = scale(totalDividendAmount);
+
+        credit(fundAccount, amount);
+
+        ClientFundTransaction tx = new ClientFundTransaction();
+        tx.setFundId(fund.getId());
+        tx.setUserId(fund.getId());
+        tx.setUserRole(UserRole.FUND);
+        tx.setAmountRsd(amount);
+        tx.setSourceAccountId(fundAccount.getId());
+        tx.setInflow(true);
+        tx.setStatus(ClientFundTransactionStatus.DIVIDEND_INFLOW);
+        tx.setCreatedAt(LocalDateTime.now());
+        tx.setFailureReason("DIVIDEND_INFLOW listingId=" + listingId);
+
+        ClientFundTransaction saved = clientFundTransactionRepository.save(tx);
+
+        fundValueSnapshotScheduler.snapshotFundIfMissing(fund);
+
+        log.info(
+                "B11 dividend inflow credited: fund={}, listing={}, amountRsd={}",
+                fundId,
+                listingId,
+                amount
+        );
+
+        return saved;
+    }
+
+    @Transactional(readOnly = true)
+    public List<ClientFundTransaction> listPendingDividends(Long fundId) {
+        return clientFundTransactionRepository.findByFundIdAndStatusOrderByCreatedAtAsc(
+                fundId,
+                ClientFundTransactionStatus.DIVIDEND_INFLOW
+        );
+    }
+
+    @Transactional
+    public List<Order> reinvestDividends(Long fundId) {
+        InvestmentFund fund = getActiveFund(fundId);
+        Account fundAccount = getFundAccountForUpdate(fund);
+        List<ClientFundTransaction> pendingDividends = listPendingDividends(fundId);
+
+        if (pendingDividends.isEmpty()) {
+            log.info("B11 reinvest skipped: fund={} nema pending dividendi.", fundId);
+            return List.of();
+        }
+
+        List<Order> createdOrders = new java.util.ArrayList<>();
+
+        for (ClientFundTransaction dividendTx : pendingDividends) {
+            Long listingId = extractListingId(dividendTx);
+
+            if (listingId == null) {
+                markFailed(dividendTx, "Nije moguce reinvestirati dividendu bez listingId reference.");
+                continue;
+            }
+
+            Listing listing = listingRepository.findById(listingId)
+                    .orElseThrow(() -> new EntityNotFoundException("Listing nije pronadjen: " + listingId));
+
+            BigDecimal dividendAmount = scale(dividendTx.getAmountRsd());
+            BigDecimal availableCash = scale(fundAccount.getAvailableBalance());
+            BigDecimal amountForReinvestment = dividendAmount.min(availableCash);
+
+            if (amountForReinvestment.signum() <= 0) {
+                markFailed(dividendTx, "Fond nema raspoloziv cash za reinvestiranje dividende.");
+                continue;
+            }
+
+            BigDecimal priceInListingCurrency = resolveBuyPrice(listing);
+            BigDecimal priceInRsd = convertToRsd(
+                    priceInListingCurrency,
+                    ListingCurrencyResolver.resolveSafe(listing, RSD)
+            );
+
+            if (priceInRsd.signum() <= 0) {
+                markFailed(dividendTx, "Cena listinga nije validna za reinvestiranje.");
+                continue;
+            }
+
+            int quantity = amountForReinvestment
+                    .divide(priceInRsd, 0, RoundingMode.FLOOR)
+                    .intValue();
+
+            if (quantity <= 0) {
+                log.warn(
+                        "B11 reinvest skipped: fund={}, tx={}, amount={} nije dovoljan za jednu hartiju {} po ceni {} RSD.",
+                        fundId,
+                        dividendTx.getId(),
+                        amountForReinvestment,
+                        listing.getTicker(),
+                        priceInRsd
+                );
+                continue;
+            }
+
+            BigDecimal reservedAmount = priceInRsd
+                    .multiply(BigDecimal.valueOf(quantity))
+                    .setScale(MONEY_SCALE, RoundingMode.HALF_UP);
+
+            if (scale(fundAccount.getAvailableBalance()).compareTo(reservedAmount) < 0) {
+                throw new InsufficientFundsException(
+                        "Fond nema dovoljno raspolozivih sredstava za reinvestiranje dividende."
+                );
+            }
+
+            Order order = createInternalBuyOrder(
+                    fund,
+                    fundAccount,
+                    listing,
+                    quantity,
+                    priceInListingCurrency,
+                    reservedAmount
+            );
+
+            createdOrders.add(order);
+
+            dividendTx.setStatus(ClientFundTransactionStatus.DIVIDEND_REINVESTED);
+            dividendTx.setCompletedAt(LocalDateTime.now());
+            dividendTx.setFailureReason(
+                    "DIVIDEND_REINVESTED orderId=" + order.getId() + ", listingId=" + listing.getId()
+            );
+            clientFundTransactionRepository.save(dividendTx);
+        }
+
+        fundValueSnapshotScheduler.snapshotFundIfMissing(fund);
+
+        return createdOrders;
+    }
+
+    @Transactional
+    public List<ClientFundTransaction> distributeDividendsToClients(Long fundId) {
+        InvestmentFund fund = getActiveFund(fundId);
+        Account fundAccount = getFundAccountForUpdate(fund);
+        List<ClientFundTransaction> pendingDividends = listPendingDividends(fundId);
+
+        if (pendingDividends.isEmpty()) {
+            log.info("B11 distribution skipped: fund={} nema pending dividendi.", fundId);
+            return List.of();
+        }
+
+        BigDecimal totalDividend = pendingDividends.stream()
+                .map(ClientFundTransaction::getAmountRsd)
+                .filter(Objects::nonNull)
+                .map(this::scale)
+                .reduce(BigDecimal.ZERO.setScale(MONEY_SCALE, RoundingMode.HALF_UP), BigDecimal::add);
+
+        if (totalDividend.signum() <= 0) {
+            return List.of();
+        }
+
+        if (scale(fundAccount.getAvailableBalance()).compareTo(totalDividend) < 0) {
+            throw new InsufficientFundsException(
+                    "Fond nema dovoljno likvidnih sredstava za raspodelu dividendi."
+            );
+        }
+
+        List<ClientFundPosition> positions = clientFundPositionRepository.findByFundId(fundId)
+                .stream()
+                .filter(position -> position.getTotalInvested() != null)
+                .filter(position -> position.getTotalInvested().signum() > 0)
+                .sorted(Comparator.comparing(ClientFundPosition::getId))
+                .toList();
+
+        BigDecimal totalInvested = positions.stream()
+                .map(ClientFundPosition::getTotalInvested)
+                .filter(Objects::nonNull)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        if (positions.isEmpty() || totalInvested.signum() <= 0) {
+            log.warn(
+                    "B11 distribution skipped: fund={} nema klijentske pozicije za proporcionalnu raspodelu.",
+                    fundId
+            );
+            return List.of();
+        }
+
+        List<ClientFundTransaction> distributions = new java.util.ArrayList<>();
+        BigDecimal distributedSoFar = BigDecimal.ZERO.setScale(MONEY_SCALE, RoundingMode.HALF_UP);
+
+        for (int i = 0; i < positions.size(); i++) {
+            ClientFundPosition position = positions.get(i);
+
+            BigDecimal clientAmount;
+
+            if (i == positions.size() - 1) {
+                clientAmount = totalDividend
+                        .subtract(distributedSoFar)
+                        .setScale(MONEY_SCALE, RoundingMode.HALF_UP);
+            } else {
+                clientAmount = totalDividend
+                        .multiply(position.getTotalInvested())
+                        .divide(totalInvested, MONEY_SCALE, RoundingMode.HALF_UP);
+
+                distributedSoFar = distributedSoFar
+                        .add(clientAmount)
+                        .setScale(MONEY_SCALE, RoundingMode.HALF_UP);
+            }
+
+            if (clientAmount.signum() <= 0) {
+                continue;
+            }
+
+            Account destinationAccount = resolveClientRsdAccountForUpdate(position.getUserId());
+
+            debit(fundAccount, clientAmount);
+            credit(destinationAccount, clientAmount);
+
+            ClientFundTransaction distribution = new ClientFundTransaction();
+            distribution.setFundId(fundId);
+            distribution.setUserId(position.getUserId());
+            distribution.setUserRole(position.getUserRole());
+            distribution.setAmountRsd(clientAmount);
+            distribution.setSourceAccountId(destinationAccount.getId());
+            distribution.setInflow(false);
+            distribution.setStatus(ClientFundTransactionStatus.DIVIDEND_DISTRIBUTED);
+            distribution.setCreatedAt(LocalDateTime.now());
+            distribution.setCompletedAt(LocalDateTime.now());
+            distribution.setFailureReason("DIVIDEND_DISTRIBUTION fromFundAccountId=" + fundAccount.getId());
+
+            distributions.add(clientFundTransactionRepository.save(distribution));
+        }
+
+        for (ClientFundTransaction pending : pendingDividends) {
+            pending.setStatus(ClientFundTransactionStatus.DIVIDEND_DISTRIBUTED);
+            pending.setCompletedAt(LocalDateTime.now());
+            pending.setFailureReason("DIVIDEND_DISTRIBUTED totalAmount=" + totalDividend);
+            clientFundTransactionRepository.save(pending);
+        }
+
+        fundValueSnapshotScheduler.snapshotFundIfMissing(fund);
+
+        log.info(
+                "B11 dividends distributed: fund={}, total={}, clients={}",
+                fundId,
+                totalDividend,
+                distributions.size()
+        );
+
+        return distributions;
+    }
+
+    @Scheduled(cron = "0 30 2 * * *")
+    public void scheduledDividendProcessing() {
+        List<InvestmentFund> activeFunds = investmentFundRepository.findByActiveTrueOrderByNameAsc();
+
+        for (InvestmentFund fund : activeFunds) {
+            try {
+                reinvestDividends(fund.getId());
+            } catch (RuntimeException ex) {
+                log.error(
+                        "B11 scheduled dividend processing failed for fund #{}: {}",
+                        fund.getId(),
+                        ex.getMessage(),
+                        ex
+                );
+            }
+        }
+    }
+
+    private Order createInternalBuyOrder(
+            InvestmentFund fund,
+            Account fundAccount,
+            Listing listing,
+            int quantity,
+            BigDecimal priceInListingCurrency,
+            BigDecimal reservedAmount
+    ) {
+        Order order = new Order();
+
+        order.setUserId(fund.getId());
+        order.setUserRole(UserRole.FUND);
+        order.setFundId(fund.getId());
+        order.setListing(listing);
+        order.setQuantity(quantity);
+        order.setRemainingPortions(quantity);
+        order.setContractSize(1);
+        order.setPricePerUnit(priceInListingCurrency);
+        order.setApproximatePrice(
+                priceInListingCurrency
+                        .multiply(BigDecimal.valueOf(quantity))
+                        .setScale(MONEY_SCALE, RoundingMode.HALF_UP)
+        );
+        order.setDirection(OrderDirection.BUY);
+        order.setOrderType(OrderType.MARKET);
+        order.setStatus(OrderStatus.APPROVED);
+        order.setApprovedBy("SYSTEM_FUND_DIVIDEND_REINVESTMENT");
+        order.setApprovedAt(LocalDateTime.now());
+        order.setCreatedAt(LocalDateTime.now());
+        order.setLastModification(LocalDateTime.now());
+        order.setDone(false);
+        order.setAfterHours(false);
+        order.setAllOrNone(false);
+        order.setMargin(false);
+        order.setReservedAccountId(fundAccount.getId());
+        order.setAccountId(fundAccount.getId());
+        order.setReservedAmount(reservedAmount);
+        order.setExchangeRate(resolveListingToRsdRate(listing));
+        order.setFxCommission(BigDecimal.ZERO);
+
+        Order saved = orderRepository.save(order);
+
+        fundReservationService.reserveForBuy(saved, fundAccount);
+
+        log.info(
+                "B11 reinvest order created: fund={}, order={}, listing={}, quantity={}, reservedRsd={}",
+                fund.getId(),
+                saved.getId(),
+                listing.getTicker(),
+                quantity,
+                reservedAmount
+        );
+
+        return saved;
+    }
+
+    private InvestmentFund getActiveFund(Long fundId) {
+        InvestmentFund fund = investmentFundRepository.findById(fundId)
+                .orElseThrow(() -> new EntityNotFoundException("Fond ne postoji: " + fundId));
+
+        if (!fund.isActive()) {
+            throw new IllegalStateException("Fond " + fund.getName() + " nije aktivan.");
+        }
+
+        return fund;
+    }
+
+    private Account getFundAccountForUpdate(InvestmentFund fund) {
+        Account account = accountRepository.findForUpdateById(fund.getAccountId())
+                .orElseThrow(() -> new EntityNotFoundException("Racun fonda ne postoji: " + fund.getAccountId()));
+
+        if (account.getStatus() != AccountStatus.ACTIVE) {
+            throw new IllegalStateException("Racun fonda nije aktivan: " + account.getAccountNumber());
+        }
+
+        return account;
+    }
+
+    private Account resolveClientRsdAccountForUpdate(Long clientId) {
+        Account selected = accountRepository
+                .findByClientIdAndStatusOrderByAvailableBalanceDesc(clientId, AccountStatus.ACTIVE)
+                .stream()
+                .filter(account -> account.getCurrency() != null)
+                .filter(account -> RSD.equalsIgnoreCase(account.getCurrency().getCode()))
+                .findFirst()
+                .orElseThrow(() -> new EntityNotFoundException("Klijent nema aktivan RSD racun: " + clientId));
+
+        return accountRepository.findForUpdateById(selected.getId()).orElse(selected);
+    }
+
+    private Long extractListingId(ClientFundTransaction tx) {
+        String reason = tx.getFailureReason();
+
+        if (reason == null) {
+            return null;
+        }
+
+        String marker = "listingId=";
+        int start = reason.indexOf(marker);
+
+        if (start < 0) {
+            return null;
+        }
+
+        start += marker.length();
+
+        int end = start;
+        while (end < reason.length() && Character.isDigit(reason.charAt(end))) {
+            end++;
+        }
+
+        if (end == start) {
+            return null;
+        }
+
+        return Long.parseLong(reason.substring(start, end));
+    }
+
+    private BigDecimal resolveBuyPrice(Listing listing) {
+        BigDecimal price = listing.getAsk() != null ? listing.getAsk() : listing.getPrice();
+
+        if (price == null || price.signum() <= 0) {
+            throw new IllegalStateException("Listing " + listing.getTicker() + " nema validnu cenu za BUY order.");
+        }
+
+        return price.setScale(MONEY_SCALE, RoundingMode.HALF_UP);
+    }
+
+    private BigDecimal resolveListingToRsdRate(Listing listing) {
+        String listingCurrency = ListingCurrencyResolver
+                .resolveSafe(listing, RSD)
+                .toUpperCase(Locale.ROOT);
+
+        if (RSD.equals(listingCurrency)) {
+            return BigDecimal.ONE;
+        }
+
+        return currencyConversionService.getRate(listingCurrency, RSD);
+    }
+
+    private BigDecimal convertToRsd(BigDecimal amount, String fromCurrency) {
+        String normalized = fromCurrency == null ? RSD : fromCurrency.toUpperCase(Locale.ROOT);
+
+        if (RSD.equals(normalized)) {
+            return scale(amount);
+        }
+
+        return currencyConversionService.convert(amount, normalized, RSD);
+    }
+
+    private void markFailed(ClientFundTransaction tx, String reason) {
+        tx.setStatus(ClientFundTransactionStatus.FAILED);
+        tx.setCompletedAt(LocalDateTime.now());
+        tx.setFailureReason(reason);
+
+        clientFundTransactionRepository.save(tx);
+    }
+
+    private void debit(Account account, BigDecimal amount) {
+        BigDecimal scaled = scale(amount);
+
+        account.setBalance(scale(account.getBalance()).subtract(scaled));
+        account.setAvailableBalance(scale(account.getAvailableBalance()).subtract(scaled));
+
+        accountRepository.save(account);
+    }
+
+    private void credit(Account account, BigDecimal amount) {
+        BigDecimal scaled = scale(amount);
+
+        account.setBalance(scale(account.getBalance()).add(scaled));
+        account.setAvailableBalance(scale(account.getAvailableBalance()).add(scaled));
+
+        accountRepository.save(account);
+    }
+
+    private BigDecimal scale(BigDecimal value) {
+        return (value == null ? BigDecimal.ZERO : value).setScale(MONEY_SCALE, RoundingMode.HALF_UP);
+    }
 }

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/investmentfund/service/InvestmentFundService.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/investmentfund/service/InvestmentFundService.java
@@ -44,19 +44,6 @@ import java.util.stream.Stream;
 /*
  * TODO [B11 + B12 - Dividende u fondovima + statistika | Nosioci: Brasanac, Milica Zoranovic]
  *
- * [B11] Integrisati priliv dividendi u fond, reinvestiranje i raspodelu klijentima:
- *   - Kada DividendScheduler isplati dividendu za akciju koja je u portfelju fonda,
- *     pozvati FundDividendService koji:
- *       1. dodaje dividendni prihod na cash (balance) fonda
- *       2. po konfiguraciji fonda (reinvest=true) odmah kupuje dodatne akcije istog listinga
- *          (BUY order sa fundId u ime fonda) — ovo je B11 reinvestiranje
- *       3. rasporedjuje neto dividendu (posle eventualnog reinvestiranja) srazmerno
- *          udelima klijenata (ClientFundPosition.units / totalUnits) i biljezi
- *          ClientFundTransaction tipa DIVIDEND_PAYOUT
- *   - Integraciona tacka: u invest() i withdraw() azurirati snapshot vrednosti fonda
- *     posle promena (snapshotFundIfMissing vec postoji — primeniti i ovde).
- *   - Klasa nosioc: FundDividendService (vec postoji u ovom paketu).
- *
  * [B12] Izloziti metrike fonda u podacima koje vraca getById / listDiscovery:
  *   - Pozvati FundStatisticsService.computeStatistics(fund) i ukljuciti rezultat
  *     u FundDetailDto (dodati polja: sharpeRatio, volatility30d, maxDrawdown,

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/dividend/DividendFundIntegrationTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/dividend/DividendFundIntegrationTest.java
@@ -1,0 +1,189 @@
+package rs.raf.banka2_bek.dividend;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import rs.raf.banka2_bek.account.repository.AccountRepository;
+import rs.raf.banka2_bek.auth.util.UserResolver;
+import rs.raf.banka2_bek.dividend.model.DividendPayout;
+import rs.raf.banka2_bek.dividend.repository.DividendPayoutRepository;
+import rs.raf.banka2_bek.dividend.service.DividendService;
+import rs.raf.banka2_bek.investmentfund.model.ClientFundTransaction;
+import rs.raf.banka2_bek.investmentfund.service.FundDividendService;
+import rs.raf.banka2_bek.order.service.CurrencyConversionService;
+import rs.raf.banka2_bek.portfolio.model.Portfolio;
+import rs.raf.banka2_bek.portfolio.repository.PortfolioRepository;
+import rs.raf.banka2_bek.stock.model.Listing;
+import rs.raf.banka2_bek.stock.repository.ListingRepository;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class DividendFundIntegrationTest {
+
+    @Autowired
+    private DividendService dividendService;
+
+    @MockitoBean
+    private DividendPayoutRepository dividendPayoutRepository;
+
+    @MockitoBean
+    private PortfolioRepository portfolioRepository;
+
+    @MockitoBean
+    private AccountRepository accountRepository;
+
+    @MockitoBean
+    private ListingRepository listingRepository;
+
+    @MockitoBean
+    private UserResolver userResolver;
+
+    @MockitoBean
+    private CurrencyConversionService currencyConversionService;
+
+    @MockitoBean
+    private FundDividendService fundDividendService;
+
+    @Test
+    @DisplayName("B9 integrates with B11: fund-owned stock dividend is credited through FundDividendService")
+    void processQuarterlyDividends_fundOwnedStock_delegatesToFundDividendService() {
+        LocalDate paymentDate = LocalDate.of(2026, 3, 31);
+
+        Portfolio fundPortfolio = Portfolio.builder()
+                .id(1L)
+                .userId(7L)
+                .userRole("FUND")
+                .listingId(10L)
+                .listingTicker("AAPL")
+                .listingName("Apple Inc.")
+                .listingType("STOCK")
+                .quantity(10)
+                .averageBuyPrice(new BigDecimal("90.0000"))
+                .publicQuantity(0)
+                .reservedQuantity(0)
+                .build();
+
+        Listing listing = new Listing();
+        listing.setId(10L);
+        listing.setTicker("AAPL");
+        listing.setName("Apple Inc.");
+        listing.setPrice(new BigDecimal("100.0000"));
+        listing.setDividendYield(new BigDecimal("0.0800"));
+        listing.setBaseCurrency("RSD");
+
+        ClientFundTransaction fundDividendTransaction = new ClientFundTransaction();
+        fundDividendTransaction.setSourceAccountId(500L);
+
+        when(portfolioRepository.findAll()).thenReturn(List.of(fundPortfolio));
+        when(dividendPayoutRepository.findByStockListingIdAndPaymentDate(10L, paymentDate))
+                .thenReturn(Collections.emptyList());
+        when(listingRepository.findById(10L)).thenReturn(Optional.of(listing));
+        when(fundDividendService.creditDividendToFund(
+                eq(7L),
+                eq(10L),
+                eq(new BigDecimal("20.0000"))
+        )).thenReturn(fundDividendTransaction);
+
+        when(dividendPayoutRepository.save(org.mockito.ArgumentMatchers.any(DividendPayout.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        dividendService.processQuarterlyDividends(paymentDate);
+
+        verify(fundDividendService).creditDividendToFund(
+                eq(7L),
+                eq(10L),
+                eq(new BigDecimal("20.0000"))
+        );
+
+        verify(accountRepository, never()).findByClientId(anyLong());
+
+        org.mockito.ArgumentCaptor<DividendPayout> payoutCaptor =
+                org.mockito.ArgumentCaptor.forClass(DividendPayout.class);
+
+        verify(dividendPayoutRepository).save(payoutCaptor.capture());
+
+        DividendPayout savedPayout = payoutCaptor.getValue();
+
+        assertEquals(7L, savedPayout.getOwnerId());
+        assertEquals("FUND", savedPayout.getOwnerType());
+        assertEquals(10L, savedPayout.getStockListingId());
+        assertEquals("AAPL", savedPayout.getStockTicker());
+        assertEquals(10, savedPayout.getQuantity());
+        assertEquals(500L, savedPayout.getCreditedAccountId());
+        assertEquals("RSD", savedPayout.getCurrencyCode());
+        assertTrue(savedPayout.getTaxExempt());
+
+        assertEquals(0, savedPayout.getGrossAmount().compareTo(new BigDecimal("20.0000")));
+        assertEquals(0, savedPayout.getNetAmount().compareTo(new BigDecimal("20.0000")));
+        assertEquals(0, savedPayout.getTax().compareTo(BigDecimal.ZERO));
+    }
+
+    @Test
+    @DisplayName("B9/B11 integration is idempotent: already paid fund dividend is skipped")
+    void processQuarterlyDividends_fundDividendAlreadyPaid_skipsB11Delegation() {
+        LocalDate paymentDate = LocalDate.of(2026, 3, 31);
+
+        Portfolio fundPortfolio = Portfolio.builder()
+                .id(1L)
+                .userId(7L)
+                .userRole("FUND")
+                .listingId(10L)
+                .listingTicker("AAPL")
+                .listingName("Apple Inc.")
+                .listingType("STOCK")
+                .quantity(10)
+                .averageBuyPrice(new BigDecimal("90.0000"))
+                .publicQuantity(0)
+                .reservedQuantity(0)
+                .build();
+
+        DividendPayout existingPayout = DividendPayout.builder()
+                .ownerId(7L)
+                .ownerType("FUND")
+                .stockListingId(10L)
+                .stockTicker("AAPL")
+                .quantity(10)
+                .priceOnDate(new BigDecimal("100.0000"))
+                .dividendYieldRate(new BigDecimal("0.020000"))
+                .grossAmount(new BigDecimal("20.0000"))
+                .tax(BigDecimal.ZERO)
+                .netAmount(new BigDecimal("20.0000"))
+                .creditedAccountId(500L)
+                .currencyCode("RSD")
+                .paymentDate(paymentDate)
+                .taxExempt(true)
+                .build();
+
+        when(portfolioRepository.findAll()).thenReturn(List.of(fundPortfolio));
+        when(dividendPayoutRepository.findByStockListingIdAndPaymentDate(10L, paymentDate))
+                .thenReturn(List.of(existingPayout));
+
+        dividendService.processQuarterlyDividends(paymentDate);
+
+        verify(fundDividendService, never()).creditDividendToFund(
+                org.mockito.ArgumentMatchers.anyLong(),
+                org.mockito.ArgumentMatchers.anyLong(),
+                org.mockito.ArgumentMatchers.any(BigDecimal.class)
+        );
+
+        verify(dividendPayoutRepository, never()).save(org.mockito.ArgumentMatchers.any(DividendPayout.class));
+        verify(accountRepository, never()).findByClientId(anyLong());
+    }
+}

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/investmentfund/FundDividendServiceTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/investmentfund/FundDividendServiceTest.java
@@ -1,79 +1,511 @@
 package rs.raf.banka2_bek.investmentfund;
 
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import rs.raf.banka2_bek.account.model.Account;
+import rs.raf.banka2_bek.account.model.AccountCategory;
+import rs.raf.banka2_bek.account.model.AccountStatus;
+import rs.raf.banka2_bek.account.repository.AccountRepository;
+import rs.raf.banka2_bek.auth.util.UserRole;
+import rs.raf.banka2_bek.currency.model.Currency;
+import rs.raf.banka2_bek.investmentfund.model.ClientFundPosition;
+import rs.raf.banka2_bek.investmentfund.model.ClientFundTransaction;
+import rs.raf.banka2_bek.investmentfund.model.ClientFundTransactionStatus;
+import rs.raf.banka2_bek.investmentfund.model.InvestmentFund;
+import rs.raf.banka2_bek.investmentfund.repository.ClientFundPositionRepository;
+import rs.raf.banka2_bek.investmentfund.repository.ClientFundTransactionRepository;
+import rs.raf.banka2_bek.investmentfund.repository.InvestmentFundRepository;
+import rs.raf.banka2_bek.investmentfund.scheduler.FundValueSnapshotScheduler;
 import rs.raf.banka2_bek.investmentfund.service.FundDividendService;
+import rs.raf.banka2_bek.order.model.Order;
+import rs.raf.banka2_bek.order.model.OrderDirection;
+import rs.raf.banka2_bek.order.model.OrderStatus;
+import rs.raf.banka2_bek.order.model.OrderType;
+import rs.raf.banka2_bek.order.repository.OrderRepository;
+import rs.raf.banka2_bek.order.service.CurrencyConversionService;
+import rs.raf.banka2_bek.order.service.FundReservationService;
+import rs.raf.banka2_bek.stock.model.Listing;
+import rs.raf.banka2_bek.stock.model.ListingType;
+import rs.raf.banka2_bek.stock.repository.ListingRepository;
 
-// ============================================================
-// TODO [B11 - Dividende u investicionim fondovima | Nosilac: Brasanac]
-//
-// Jedinicni testovi za FundDividendService pokrivajuci sve
-// putanje implementiranih metoda.
-//
-// IMPLEMENTIRATI (jedan @Test po stavci):
-//
-//   - creditDividendToFund_creditsCorrectAmount
-//       Stub InvestmentFundRepository i AccountRepository.
-//       Pozovi creditDividendToFund, verifikuj da je cash racun
-//       fonda kreditovan za tacno totalDividendAmount i da je
-//       ClientFundTransaction sacuvan sa ispravnim tipom i iznosom.
-//
-//   - creditDividendToFund_fundNotFound_throwsException
-//       Kada fundId ne postoji, ocekuj odgovarajuci izuzetak
-//       (EntityNotFoundException ili IllegalArgumentException).
-//
-//   - reinvestDividends_sufficientCash_placesOrder
-//       Stub fond sa cash > currentPrice; verifikuj da je BUY
-//       order kreiran sa ispravnom kolicinom (floor(cash/price))
-//       i da je dividenda oznacena kao REINVESTED.
-//
-//   - reinvestDividends_insufficientCash_noOrderPlaced
-//       Stub cash < currentPrice; verifikuj da order nije kreiran
-//       i da je odgovarajuci log.warn emitovan (Mockito
-//       ArgumentCaptor ili spy na loggeru).
-//
-//   - reinvestDividends_noPendingDividends_doesNothing
-//       Stub listPendingDividends da vrati praznu listu;
-//       verifikuj nulte interakcije sa OrderRepository.
-//
-//   - distributeDividendsToClients_distributesSrazmerno
-//       Stub dva klijenta sa udelima 70% / 30%; verifikuj da su
-//       oba kreditovana tacno proporcionalnim iznosima i da su
-//       kreirani odgovarajuci ClientFundTransaction zapisi.
-//
-//   - distributeDividendsToClients_alreadyDistributed_isIdempotent
-//       Stub dividendu sa statusom DISTRIBUTED; verifikuj da
-//       ponavljanje poziva ne menja stanje (nema novih
-//       ClientFundTransaction zapisa, nema kreditiranja).
-//
-//   - distributeDividendsToClients_noPositions_skips
-//       Fond bez klijentskih pozicija; verifikuj da metoda
-//       zavrsava bez gresaka i bez zapisa.
-//
-//   - listPendingDividends_returnsPendingOnly
-//       Stub mix PENDING i REINVESTED zapisa; verifikuj da
-//       rezultat sadrzi samo PENDING.
-//
-//   - scheduledDividendProcessing_exceptionInOneFund_continuesOthers
-//       Stub dva fonda; za prvi neka reinvestDividends baci
-//       RuntimeException; verifikuj da je drugi fond i dalje
-//       obradjivan (error isolation kao u SavingsScheduler).
-//
-// Konvencija: pratiti paket `savings` kao sablon.
-// Spec: Zadaci_Backend.pdf, zadatak B11.
-// ============================================================
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
 @ExtendWith(MockitoExtension.class)
 class FundDividendServiceTest {
 
     @Mock
-    // TODO: dodati polja @Mock za sve zavisnosti koje FundDividendService injektuje
-    // (InvestmentFundRepository, ClientFundPositionRepository,
-    //  ClientFundTransactionRepository, AccountRepository, itd.)
-    private Object placeholder;
+    private InvestmentFundRepository investmentFundRepository;
+
+    @Mock
+    private ClientFundTransactionRepository clientFundTransactionRepository;
+
+    @Mock
+    private ClientFundPositionRepository clientFundPositionRepository;
+
+    @Mock
+    private AccountRepository accountRepository;
+
+    @Mock
+    private ListingRepository listingRepository;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private FundReservationService fundReservationService;
+
+    @Mock
+    private CurrencyConversionService currencyConversionService;
+
+    @Mock
+    private FundValueSnapshotScheduler fundValueSnapshotScheduler;
 
     @InjectMocks
     private FundDividendService service;
 
+    @Test
+    @DisplayName("creditDividendToFund credits fund account and saves DIVIDEND_INFLOW transaction")
+    void creditDividendToFund_creditsCorrectAmount() {
+        InvestmentFund fund = activeFund(1L, 100L);
+        Account fundAccount = fundAccount(100L, "1000.0000", "1000.0000");
+
+        when(investmentFundRepository.findById(1L)).thenReturn(Optional.of(fund));
+        when(accountRepository.findForUpdateById(100L)).thenReturn(Optional.of(fundAccount));
+        when(clientFundTransactionRepository.save(any(ClientFundTransaction.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        ClientFundTransaction result = service.creditDividendToFund(
+                1L,
+                10L,
+                new BigDecimal("250.0000")
+        );
+
+        assertBigDecimalEquals("1250.0000", fundAccount.getBalance());
+        assertBigDecimalEquals("1250.0000", fundAccount.getAvailableBalance());
+
+        ArgumentCaptor<ClientFundTransaction> txCaptor =
+                ArgumentCaptor.forClass(ClientFundTransaction.class);
+
+        verify(clientFundTransactionRepository).save(txCaptor.capture());
+
+        ClientFundTransaction saved = txCaptor.getValue();
+
+        assertEquals(1L, saved.getFundId());
+        assertEquals(1L, saved.getUserId());
+        assertEquals(UserRole.FUND, saved.getUserRole());
+        assertTrue(saved.isInflow());
+        assertEquals(ClientFundTransactionStatus.DIVIDEND_INFLOW, saved.getStatus());
+        assertBigDecimalEquals("250.0000", saved.getAmountRsd());
+        assertEquals(100L, saved.getSourceAccountId());
+        assertTrue(saved.getFailureReason().contains("listingId=10"));
+
+        assertSame(saved, result);
+
+        verify(accountRepository).save(fundAccount);
+        verify(fundValueSnapshotScheduler).snapshotFundIfMissing(fund);
+    }
+
+    @Test
+    @DisplayName("creditDividendToFund throws when fund does not exist")
+    void creditDividendToFund_fundNotFound_throwsException() {
+        when(investmentFundRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThrows(
+                EntityNotFoundException.class,
+                () -> service.creditDividendToFund(999L, 10L, new BigDecimal("100.0000"))
+        );
+
+        verifyNoInteractions(accountRepository);
+        verifyNoInteractions(clientFundTransactionRepository);
+    }
+
+    @Test
+    @DisplayName("listPendingDividends returns repository results for DIVIDEND_INFLOW status")
+    void listPendingDividends_returnsPendingOnly() {
+        ClientFundTransaction pending = dividendTx(
+                1L,
+                10L,
+                "300.0000",
+                ClientFundTransactionStatus.DIVIDEND_INFLOW
+        );
+
+        when(clientFundTransactionRepository.findByFundIdAndStatusOrderByCreatedAtAsc(
+                1L,
+                ClientFundTransactionStatus.DIVIDEND_INFLOW
+        )).thenReturn(List.of(pending));
+
+        List<ClientFundTransaction> result = service.listPendingDividends(1L);
+
+        assertEquals(1, result.size());
+        assertSame(pending, result.get(0));
+
+        verify(clientFundTransactionRepository).findByFundIdAndStatusOrderByCreatedAtAsc(
+                1L,
+                ClientFundTransactionStatus.DIVIDEND_INFLOW
+        );
+    }
+
+    @Test
+    @DisplayName("reinvestDividends creates MARKET BUY order when dividend is sufficient")
+    void reinvestDividends_sufficientCash_placesOrder() {
+        InvestmentFund fund = activeFund(1L, 100L);
+        Account fundAccount = fundAccount(100L, "1000.0000", "1000.0000");
+
+        ClientFundTransaction pendingDividend = dividendTx(
+                1L,
+                10L,
+                "900.0000",
+                ClientFundTransactionStatus.DIVIDEND_INFLOW
+        );
+
+        Listing listing = stockListing(10L, "AAPL", "200.0000");
+
+        when(investmentFundRepository.findById(1L)).thenReturn(Optional.of(fund));
+        when(accountRepository.findForUpdateById(100L)).thenReturn(Optional.of(fundAccount));
+        when(clientFundTransactionRepository.findByFundIdAndStatusOrderByCreatedAtAsc(
+                1L,
+                ClientFundTransactionStatus.DIVIDEND_INFLOW
+        )).thenReturn(List.of(pendingDividend));
+        when(listingRepository.findById(10L)).thenReturn(Optional.of(listing));
+        when(orderRepository.save(any(Order.class))).thenAnswer(invocation -> {
+            Order order = invocation.getArgument(0);
+            order.setId(700L);
+            return order;
+        });
+        when(clientFundTransactionRepository.save(any(ClientFundTransaction.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        List<Order> createdOrders = service.reinvestDividends(1L);
+
+        assertEquals(1, createdOrders.size());
+
+        Order order = createdOrders.get(0);
+
+        assertEquals(700L, order.getId());
+        assertEquals(1L, order.getUserId());
+        assertEquals(UserRole.FUND, order.getUserRole());
+        assertEquals(1L, order.getFundId());
+        assertEquals(listing, order.getListing());
+        assertEquals(OrderDirection.BUY, order.getDirection());
+        assertEquals(OrderType.MARKET, order.getOrderType());
+        assertEquals(OrderStatus.APPROVED, order.getStatus());
+        assertEquals(4, order.getQuantity());
+        assertEquals(4, order.getRemainingPortions());
+        assertBigDecimalEquals("800.0000", order.getReservedAmount());
+
+        assertEquals(ClientFundTransactionStatus.DIVIDEND_REINVESTED, pendingDividend.getStatus());
+        assertNotNull(pendingDividend.getCompletedAt());
+        assertTrue(pendingDividend.getFailureReason().contains("orderId=700"));
+
+        verify(orderRepository).save(any(Order.class));
+        verify(fundReservationService).reserveForBuy(order, fundAccount);
+        verify(clientFundTransactionRepository).save(pendingDividend);
+        verify(fundValueSnapshotScheduler).snapshotFundIfMissing(fund);
+    }
+
+    @Test
+    @DisplayName("reinvestDividends does not create order when cash is below one share price")
+    void reinvestDividends_insufficientCash_noOrderPlaced() {
+        InvestmentFund fund = activeFund(1L, 100L);
+        Account fundAccount = fundAccount(100L, "100.0000", "100.0000");
+
+        ClientFundTransaction pendingDividend = dividendTx(
+                1L,
+                10L,
+                "100.0000",
+                ClientFundTransactionStatus.DIVIDEND_INFLOW
+        );
+
+        Listing listing = stockListing(10L, "AAPL", "200.0000");
+
+        when(investmentFundRepository.findById(1L)).thenReturn(Optional.of(fund));
+        when(accountRepository.findForUpdateById(100L)).thenReturn(Optional.of(fundAccount));
+        when(clientFundTransactionRepository.findByFundIdAndStatusOrderByCreatedAtAsc(
+                1L,
+                ClientFundTransactionStatus.DIVIDEND_INFLOW
+        )).thenReturn(List.of(pendingDividend));
+        when(listingRepository.findById(10L)).thenReturn(Optional.of(listing));
+
+        List<Order> result = service.reinvestDividends(1L);
+
+        assertTrue(result.isEmpty());
+        assertEquals(ClientFundTransactionStatus.DIVIDEND_INFLOW, pendingDividend.getStatus());
+
+        verifyNoInteractions(orderRepository);
+        verifyNoInteractions(fundReservationService);
+        verify(clientFundTransactionRepository, never()).save(any(ClientFundTransaction.class));
+        verify(fundValueSnapshotScheduler).snapshotFundIfMissing(fund);
+    }
+
+    @Test
+    @DisplayName("reinvestDividends does nothing when there are no pending dividends")
+    void reinvestDividends_noPendingDividends_doesNothing() {
+        InvestmentFund fund = activeFund(1L, 100L);
+        Account fundAccount = fundAccount(100L, "1000.0000", "1000.0000");
+
+        when(investmentFundRepository.findById(1L)).thenReturn(Optional.of(fund));
+        when(accountRepository.findForUpdateById(100L)).thenReturn(Optional.of(fundAccount));
+        when(clientFundTransactionRepository.findByFundIdAndStatusOrderByCreatedAtAsc(
+                1L,
+                ClientFundTransactionStatus.DIVIDEND_INFLOW
+        )).thenReturn(List.of());
+
+        List<Order> result = service.reinvestDividends(1L);
+
+        assertTrue(result.isEmpty());
+
+        verifyNoInteractions(listingRepository);
+        verifyNoInteractions(orderRepository);
+        verifyNoInteractions(fundReservationService);
+        verify(fundValueSnapshotScheduler, never()).snapshotFundIfMissing(fund);
+    }
+
+    @Test
+    @DisplayName("distributeDividendsToClients distributes dividends proportionally by totalInvested")
+    void distributeDividendsToClients_distributesSrazmerno() {
+        InvestmentFund fund = activeFund(1L, 100L);
+        Account fundAccount = fundAccount(100L, "2000.0000", "2000.0000");
+
+        Account clientOneAccount = clientAccount(201L, "0.0000", "0.0000");
+        Account clientTwoAccount = clientAccount(202L, "0.0000", "0.0000");
+
+        ClientFundTransaction pendingDividend = dividendTx(
+                1L,
+                10L,
+                "1000.0000",
+                ClientFundTransactionStatus.DIVIDEND_INFLOW
+        );
+
+        ClientFundPosition positionOne = position(1L, 1L, 11L, "700.0000");
+        ClientFundPosition positionTwo = position(2L, 1L, 22L, "300.0000");
+
+        when(investmentFundRepository.findById(1L)).thenReturn(Optional.of(fund));
+        when(accountRepository.findForUpdateById(100L)).thenReturn(Optional.of(fundAccount));
+        when(clientFundTransactionRepository.findByFundIdAndStatusOrderByCreatedAtAsc(
+                1L,
+                ClientFundTransactionStatus.DIVIDEND_INFLOW
+        )).thenReturn(List.of(pendingDividend));
+        when(clientFundPositionRepository.findByFundId(1L)).thenReturn(List.of(positionOne, positionTwo));
+
+        when(accountRepository.findByClientIdAndStatusOrderByAvailableBalanceDesc(11L, AccountStatus.ACTIVE))
+                .thenReturn(List.of(clientOneAccount));
+        when(accountRepository.findByClientIdAndStatusOrderByAvailableBalanceDesc(22L, AccountStatus.ACTIVE))
+                .thenReturn(List.of(clientTwoAccount));
+
+        when(accountRepository.findForUpdateById(201L)).thenReturn(Optional.of(clientOneAccount));
+        when(accountRepository.findForUpdateById(202L)).thenReturn(Optional.of(clientTwoAccount));
+
+        when(clientFundTransactionRepository.save(any(ClientFundTransaction.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        List<ClientFundTransaction> distributions = service.distributeDividendsToClients(1L);
+
+        assertEquals(2, distributions.size());
+
+        assertBigDecimalEquals("1000.0000", fundAccount.getBalance());
+        assertBigDecimalEquals("1000.0000", fundAccount.getAvailableBalance());
+
+        assertBigDecimalEquals("700.0000", clientOneAccount.getBalance());
+        assertBigDecimalEquals("700.0000", clientOneAccount.getAvailableBalance());
+
+        assertBigDecimalEquals("300.0000", clientTwoAccount.getBalance());
+        assertBigDecimalEquals("300.0000", clientTwoAccount.getAvailableBalance());
+
+        assertEquals(ClientFundTransactionStatus.DIVIDEND_DISTRIBUTED, distributions.get(0).getStatus());
+        assertEquals(ClientFundTransactionStatus.DIVIDEND_DISTRIBUTED, distributions.get(1).getStatus());
+        assertEquals(ClientFundTransactionStatus.DIVIDEND_DISTRIBUTED, pendingDividend.getStatus());
+
+        verify(fundValueSnapshotScheduler).snapshotFundIfMissing(fund);
+    }
+
+    @Test
+    @DisplayName("distributeDividendsToClients is idempotent when dividend is already distributed")
+    void distributeDividendsToClients_alreadyDistributed_isIdempotent() {
+        InvestmentFund fund = activeFund(1L, 100L);
+        Account fundAccount = fundAccount(100L, "1000.0000", "1000.0000");
+
+        when(investmentFundRepository.findById(1L)).thenReturn(Optional.of(fund));
+        when(accountRepository.findForUpdateById(100L)).thenReturn(Optional.of(fundAccount));
+        when(clientFundTransactionRepository.findByFundIdAndStatusOrderByCreatedAtAsc(
+                1L,
+                ClientFundTransactionStatus.DIVIDEND_INFLOW
+        )).thenReturn(List.of());
+
+        List<ClientFundTransaction> result = service.distributeDividendsToClients(1L);
+
+        assertTrue(result.isEmpty());
+        assertBigDecimalEquals("1000.0000", fundAccount.getBalance());
+        assertBigDecimalEquals("1000.0000", fundAccount.getAvailableBalance());
+
+        verifyNoInteractions(clientFundPositionRepository);
+        verify(clientFundTransactionRepository, never()).save(any(ClientFundTransaction.class));
+        verify(accountRepository, never()).save(any(Account.class));
+        verify(fundValueSnapshotScheduler, never()).snapshotFundIfMissing(fund);
+    }
+
+    @Test
+    @DisplayName("distributeDividendsToClients skips when fund has no client positions")
+    void distributeDividendsToClients_noPositions_skips() {
+        InvestmentFund fund = activeFund(1L, 100L);
+        Account fundAccount = fundAccount(100L, "1000.0000", "1000.0000");
+
+        ClientFundTransaction pendingDividend = dividendTx(
+                1L,
+                10L,
+                "1000.0000",
+                ClientFundTransactionStatus.DIVIDEND_INFLOW
+        );
+
+        when(investmentFundRepository.findById(1L)).thenReturn(Optional.of(fund));
+        when(accountRepository.findForUpdateById(100L)).thenReturn(Optional.of(fundAccount));
+        when(clientFundTransactionRepository.findByFundIdAndStatusOrderByCreatedAtAsc(
+                1L,
+                ClientFundTransactionStatus.DIVIDEND_INFLOW
+        )).thenReturn(List.of(pendingDividend));
+        when(clientFundPositionRepository.findByFundId(1L)).thenReturn(List.of());
+
+        List<ClientFundTransaction> result = service.distributeDividendsToClients(1L);
+
+        assertTrue(result.isEmpty());
+        assertEquals(ClientFundTransactionStatus.DIVIDEND_INFLOW, pendingDividend.getStatus());
+        assertBigDecimalEquals("1000.0000", fundAccount.getBalance());
+
+        verify(clientFundTransactionRepository, never()).save(any(ClientFundTransaction.class));
+        verify(fundValueSnapshotScheduler, never()).snapshotFundIfMissing(fund);
+    }
+
+    @Test
+    @DisplayName("scheduledDividendProcessing continues with other funds if one fund fails")
+    void scheduledDividendProcessing_exceptionInOneFund_continuesOthers() {
+        InvestmentFund firstFund = activeFund(1L, 101L);
+        InvestmentFund secondFund = activeFund(2L, 102L);
+
+        FundDividendService spyService = spy(service);
+
+        when(investmentFundRepository.findByActiveTrueOrderByNameAsc())
+                .thenReturn(List.of(firstFund, secondFund));
+
+        doThrow(new RuntimeException("boom")).when(spyService).reinvestDividends(1L);
+        doReturn(List.of()).when(spyService).reinvestDividends(2L);
+
+        spyService.scheduledDividendProcessing();
+
+        verify(spyService).reinvestDividends(1L);
+        verify(spyService).reinvestDividends(2L);
+    }
+
+    private InvestmentFund activeFund(Long fundId, Long accountId) {
+        InvestmentFund fund = new InvestmentFund();
+        fund.setId(fundId);
+        fund.setName("Test Fund " + fundId);
+        fund.setAccountId(accountId);
+        fund.setManagerEmployeeId(1L);
+        fund.setActive(true);
+        return fund;
+    }
+
+    private Account fundAccount(Long id, String balance, String availableBalance) {
+        return Account.builder()
+                .id(id)
+                .accountNumber("FUND-" + id)
+                .currency(rsdCurrency())
+                .balance(new BigDecimal(balance))
+                .availableBalance(new BigDecimal(availableBalance))
+                .reservedAmount(BigDecimal.ZERO)
+                .status(AccountStatus.ACTIVE)
+                .accountCategory(AccountCategory.FUND)
+                .build();
+    }
+
+    private Account clientAccount(Long id, String balance, String availableBalance) {
+        return Account.builder()
+                .id(id)
+                .accountNumber("CLIENT-" + id)
+                .currency(rsdCurrency())
+                .balance(new BigDecimal(balance))
+                .availableBalance(new BigDecimal(availableBalance))
+                .reservedAmount(BigDecimal.ZERO)
+                .status(AccountStatus.ACTIVE)
+                .accountCategory(AccountCategory.CLIENT)
+                .build();
+    }
+
+    private Currency rsdCurrency() {
+        Currency currency = new Currency();
+        currency.setCode("RSD");
+        currency.setName("Serbian dinar");
+        currency.setSymbol("RSD");
+        currency.setCountry("Serbia");
+        currency.setActive(true);
+        return currency;
+    }
+
+    private ClientFundTransaction dividendTx(
+            Long fundId,
+            Long listingId,
+            String amount,
+            ClientFundTransactionStatus status
+    ) {
+        ClientFundTransaction tx = new ClientFundTransaction();
+        tx.setId(300L + listingId);
+        tx.setFundId(fundId);
+        tx.setUserId(fundId);
+        tx.setUserRole(UserRole.FUND);
+        tx.setAmountRsd(new BigDecimal(amount));
+        tx.setSourceAccountId(100L);
+        tx.setInflow(true);
+        tx.setStatus(status);
+        tx.setFailureReason("DIVIDEND_INFLOW listingId=" + listingId);
+        return tx;
+    }
+
+    private Listing stockListing(Long id, String ticker, String price) {
+        Listing listing = new Listing();
+        listing.setId(id);
+        listing.setTicker(ticker);
+        listing.setName(ticker + " stock");
+        listing.setListingType(ListingType.STOCK);
+        listing.setExchangeAcronym("BELEX");
+        listing.setQuoteCurrency("RSD");
+        listing.setPrice(new BigDecimal(price));
+        listing.setAsk(new BigDecimal(price));
+        return listing;
+    }
+
+    private ClientFundPosition position(Long id, Long fundId, Long clientId, String totalInvested) {
+        ClientFundPosition position = new ClientFundPosition();
+        position.setId(id);
+        position.setFundId(fundId);
+        position.setUserId(clientId);
+        position.setUserRole(UserRole.CLIENT);
+        position.setTotalInvested(new BigDecimal(totalInvested));
+        return position;
+    }
+
+    private void assertBigDecimalEquals(String expected, BigDecimal actual) {
+        assertEquals(0, new BigDecimal(expected).compareTo(actual));
+    }
 }


### PR DESCRIPTION
Implementiran B11 uz 10 unit testova i 2 integraciona testa.

Unit testovi:
- `FundDividendServiceTest`
- ukupno 10 testova
- pokrivaju:
  - uplatu dividende na račun fonda
  - kreiranje `DIVIDEND_INFLOW` transakcije
  - slučaj kada fond ne postoji
  - dohvat pending dividendi
  - reinvestiranje dividendi kroz `BUY MARKET` order
  - slučaj kada nema dovoljno sredstava za kupovinu
  - slučaj kada nema pending dividendi
  - proporcionalnu raspodelu 70% / 30%
  - idempotentnost kod već raspodeljenih dividendi
  - scheduler ponašanje kada obrada jednog fonda pukne

Integracioni testovi:
- `DividendFundIntegrationTest`
- ukupno 2 testa
- pokrivaju:
  - integraciju B9 i B11 mehanizma
  - proveru da se dividenda za `FUND` portfolio prosleđuje u `FundDividendService`
  - proveru da se već isplaćena fondovska dividenda ne obrađuje ponovo

Rezultati testiranja:
- B11 unit testovi: 10 passed
- B11 integracioni testovi: 2 passed
- svi testovi: 2673 passed, 0 failures, 0 errors, 13 skipped
- checkstyle: 0 violations