### PR TITLE
B2: Validacija unosa i DB lockout zaštita od brute-force napada

### DIFF
--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/auth/config/GlobalExceptionHandler.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/auth/config/GlobalExceptionHandler.java
@@ -105,6 +105,9 @@ public class GlobalExceptionHandler {
             status = HttpStatus.NOT_FOUND;
         } else if (cause instanceof AccessDeniedException) {
             status = HttpStatus.FORBIDDEN;
+        } else if (cause instanceof AuthenticationFailedException
+                || cause instanceof AccountLockoutService.AccountLockedException) {
+            status = HttpStatus.UNAUTHORIZED;
         }
         return ResponseEntity.status(status).body(new MessageResponseDto(message));
     }

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/auth/dto/RegisterRequestDto.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/auth/dto/RegisterRequestDto.java
@@ -1,5 +1,6 @@
 package rs.raf.banka2_bek.auth.dto;
 
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -31,49 +32,11 @@ public class RegisterRequestDto {
     @Size(max = 50)
     private String username;
 
-    /*
-     * // TODO [B2 - Validacija + brute-force | Nosilac: Andjela Vilcek]
-     *
-     * Dodati Jakarta Validation anotacije na polja phone i dateOfBirth:
-     *
-     * 1. Telefon — validacija formata:
-     *    Trenutno: samo @Size(max = 20), nema provere da su cifre.
-     *    Trebalo bi dodati @Pattern ispod @Size:
-     *
-     *      @Pattern(
-     *          regexp = "^\\+?[0-9]{6,20}$",
-     *          message = "Telefon sme da sadrzi samo cifre uz opcioni vodeci znak +"
-     *      )
-     *
-     *    Regex objasnjenje:
-     *      ^\+?   — opcioni vodeci plus (medjunarodni format)
-     *      [0-9]+ — samo cifre
-     *      {6,20} — min 6 (kratki lokalni brojevi), max 20 (E.164 max je 15 + prefix)
-     *
-     * 2. Datum rodjenja — ne sme biti u buducnosti:
-     *    Trenutno: Long (Unix ms), nema validacije opsega.
-     *    Opcija A (preporucena za Long tip) — custom constraint ili
-     *    @AssertTrue metoda u samom DTO-u:
-     *
-     *      @AssertTrue(message = "Datum rodjenja ne sme biti u buducnosti")
-     *      public boolean isDateOfBirthValid() {
-     *          return dateOfBirth == null
-     *              || dateOfBirth <= java.time.Instant.now().toEpochMilli();
-     *      }
-     *
-     *    Opcija B — promeniti tip polja na LocalDate i koristiti @Past:
-     *
-     *      @Past(message = "Datum rodjenja mora biti u proslosti")
-     *      private LocalDate dateOfBirth;
-     *
-     *    Uz Opciju B potrebno je azurirati AuthService.register() koji
-     *    poziva user.setDateOfBirth(request.getDateOfBirth()) i ocekuje Long.
-     *
-     * 3. Osigurati da RegisterController (ili odgovarajuci @RestController)
-     *    ima @Valid/@Validated anotaciju na parametru requestBody,
-     *    inace ove anotacije nemaju efekta pri pozivu.
-     */
     @Size(max = 20)
+    @Pattern(
+            regexp = "^\\+?[0-9]{6,20}$",
+            message = "Telefon sme da sadrzi samo cifre uz opcioni vodeci znak +"
+    )
     private String phone;
 
     @Size(max = 255)
@@ -157,5 +120,11 @@ public class RegisterRequestDto {
 
     public void setGender(String gender) {
         this.gender = gender;
+    }
+
+    @AssertTrue(message = "Datum rodjenja ne sme biti u buducnosti")
+    public boolean isDateOfBirthValid() {
+        return dateOfBirth == null
+                || dateOfBirth <= java.time.Instant.now().toEpochMilli();
     }
 }

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/auth/model/User.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/auth/model/User.java
@@ -5,6 +5,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 
@@ -59,29 +60,12 @@ public class User implements UserDetails {
     @Column(nullable = false, length = 50)
     private String role = "CLIENT";
 
-    /*
-     * // TODO [B2 - Validacija + brute-force | Nosilac: Andjela Vilcek]
-     *
-     * Dodati sledeca dva polja radi DB-baziranog brute-force lockout-a
-     * (zamena za trenutnu Caffeine in-memory implementaciju u
-     * AccountLockoutService koja ne preziva restart i ne radi u
-     * multi-instance deploy-u):
-     *
-     *   @org.hibernate.annotations.ColumnDefault("0")
-     *   @Column(nullable = false)
-     *   private Integer failedLoginAttempts = 0;
-     *
-     *   @Column(nullable = true)
-     *   private java.time.LocalDateTime accountLockedUntil;
-     *
-     * Napomene:
-     * - Hibernate ddl-auto=update automatski doda kolone pri sledecem startu.
-     * - Dodati odgovarajuce getter/setter metode.
-     * - isAccountNonLocked() (linija ~130) treba da vrati
-     *   accountLockedUntil == null || accountLockedUntil.isBefore(LocalDateTime.now())
-     *   umesto hard-coded true.
-     * - Videti AccountLockoutService.java za detalje migracije logike.
-     */
+    @org.hibernate.annotations.ColumnDefault("0")
+    @Column(nullable = false)
+    private Integer failedLoginAttempts = 0;
+
+    @Column(nullable = true)
+    private LocalDateTime accountLockedUntil;
 
     public User() {
     }
@@ -151,7 +135,7 @@ public class User implements UserDetails {
 
     @Override
     public boolean isAccountNonLocked() {
-        return true;
+        return accountLockedUntil == null || accountLockedUntil.isBefore(LocalDateTime.now());
     }
 
     @Override
@@ -222,5 +206,21 @@ public class User implements UserDetails {
 
     public void setRole(String role) {
         this.role = role;
+    }
+
+    public Integer getFailedLoginAttempts() {
+        return failedLoginAttempts;
+    }
+
+    public void setFailedLoginAttempts(Integer failedLoginAttempts) {
+        this.failedLoginAttempts = failedLoginAttempts;
+    }
+
+    public LocalDateTime getAccountLockedUntil() {
+        return accountLockedUntil;
+    }
+
+    public void setAccountLockedUntil(LocalDateTime accountLockedUntil) {
+        this.accountLockedUntil = accountLockedUntil;
     }
 }

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/auth/service/AccountLockoutService.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/auth/service/AccountLockoutService.java
@@ -1,183 +1,267 @@
 package rs.raf.banka2_bek.auth.service;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
-import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import rs.raf.banka2_bek.auth.model.User;
+import rs.raf.banka2_bek.auth.repository.UserRepository;
+import rs.raf.banka2_bek.employee.model.Employee;
+import rs.raf.banka2_bek.employee.repository.EmployeeRepository;
+import rs.raf.banka2_bek.notification.service.MailSenderService;
 
 import java.time.Duration;
-import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.Locale;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Optional;
 
 /**
- * Opciono.2 — Account lockout posle X neuspesnih login pokusaja.
- *
- * Spec Celina 1, Scenario 5: "Posle 4 neuspeha, peti unos pogresne lozinke
- * → sistem zaključava nalog na određeni vremenski period". Spec eksplicitno
- * navodi ovo kao "Za nadogradnju" — opciono.
- *
- * Razlikuje se od {@link rs.raf.banka2_bek.auth.config.AuthRateLimitFilter}:
- *   * RateLimitFilter limitira po IP-u (10 req/min) — sprecava brute force.
- *   * AccountLockout limitira po EMAIL-u (5 failed → 15min lock) —
- *     sprecava credential stuffing kad napadac probava razne IP-e.
- *
- * In-memory implementacija (Caffeine), ne preziva restart. Za production
- * deploy zahteva Redis ili sl. shared store da bi radio kroz multiple
- * instance. Za KT3 demo dovoljno.
+ * Account lockout posle X neuspesnih login pokusaja — stanje se cuva u bazi
+ * na entitetima {@link User} i {@link Employee}.
  */
 @Slf4j
 @Service
 public class AccountLockoutService {
 
-    /*
-     * // TODO [B2 - Validacija + brute-force | Nosilac: Andjela Vilcek]
-     *
-     * Preraditi servis sa in-memory (Caffeine) na DB-bazirano stanje
-     * koristeci nova polja entiteta User.failedLoginAttempts i
-     * User.accountLockedUntil (analogno za Employee):
-     *
-     * 1. BRISANJE Caffeine cache-a:
-     *    - Ukloniti polja failedAttempts: Cache<String, AtomicInteger> i
-     *      lockedUntil: Cache<String, Instant>.
-     *    - Ukloniti @PostConstruct init() metodu.
-     *    - Ukloniti @Value lockout property-je (ili ostaviti za timeout
-     *      konfiguraciju, po izboru).
-     *
-     * 2. assertNotLocked(email):
-     *    - Ucitati User ili Employee po email-u iz repozitorijuma.
-     *    - Proveriti accountLockedUntil != null &&
-     *      accountLockedUntil.isAfter(LocalDateTime.now()).
-     *    - Ako je lock aktivan, baciti AccountLockedException sa preostalim
-     *      vremenom kao i sada.
-     *
-     * 3. recordFailure(email) — posle 5 uzastopnih neuspesnih pokusaja:
-     *    - Uvecati failedLoginAttempts u bazi (UserRepository.save /
-     *      EmployeeRepository.save).
-     *    - Kad failedLoginAttempts >= maxFailedAttempts, postaviti
-     *      accountLockedUntil = LocalDateTime.now().plusMinutes(10).
-     *    - Poslati email korisniku o zakljucavanju (koristiti postojeci
-     *      MailSenderService ili ApplicationEventPublisher).
-     *    - Baciti AccountLockedException odmah (kao i sada).
-     *
-     * 4. recordSuccess(email):
-     *    - Nulirati failedLoginAttempts = 0.
-     *    - Postaviti accountLockedUntil = null (otkljucati nalog).
-     *    - Sacuvati u bazi.
-     *
-     * 5. resetPassword tok u AuthService:
-     *    - Posle uspesne promene lozinke, takodje pozvati recordSuccess(email)
-     *      da se otkljuca nalog i nulira brojac.
-     *
-     * VAZNO: metoda mora biti @Transactional jer radi write nad entitetima.
-     * Paziti na lazyno ucitavanje entiteta — koristiti explicit fetch ili
-     * @Transactional(readOnly = false) u pozivajucem servisu.
-     */
-
-    /** Posle ovoliko neuspeha — racun je lock-ovan. */
     @Value("${auth.lockout.max-failed-attempts:5}")
     private int maxFailedAttempts;
 
-    /** Trajanje lock-a u minutama. */
-    @Value("${auth.lockout.lock-duration-minutes:15}")
+    @Value("${auth.lockout.lock-duration-minutes:10}")
     private int lockDurationMinutes;
 
-    /** Window u kome se broje neuspesi (resetuje se posle uspesnog login-a). */
-    @Value("${auth.lockout.attempt-window-minutes:30}")
-    private int attemptWindowMinutes;
+    private final UserRepository userRepository;
+    private final EmployeeRepository employeeRepository;
+    private final MailSenderService mailSenderService;
 
-    private Cache<String, AtomicInteger> failedAttempts;
-    private Cache<String, Instant> lockedUntil;
-
-    @PostConstruct
-    public void init() {
-        this.failedAttempts = Caffeine.newBuilder()
-                .expireAfterWrite(Duration.ofMinutes(attemptWindowMinutes))
-                .maximumSize(50_000)
-                .build();
-        this.lockedUntil = Caffeine.newBuilder()
-                .expireAfterWrite(Duration.ofMinutes(lockDurationMinutes))
-                .maximumSize(50_000)
-                .build();
+    public AccountLockoutService(UserRepository userRepository,
+                                 EmployeeRepository employeeRepository,
+                                 MailSenderService mailSenderService) {
+        this.userRepository = userRepository;
+        this.employeeRepository = employeeRepository;
+        this.mailSenderService = mailSenderService;
     }
 
     /**
      * Baca {@link AccountLockedException} ako je email trenutno lock-ovan.
      * Treba pozvati pre nego sto se proveri lozinka.
-     *
-     * Poruka je na srpskom (Bug T1-017 — pre fix-a poruka je bila pomesana
-     * SR/EN sto je FE prosledjivao 1:1 korisniku).
      */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void assertNotLocked(String email) {
         if (email == null) return;
-        String key = normalize(email);
-        Instant locked = lockedUntil.getIfPresent(key);
-        if (locked != null && locked.isAfter(Instant.now())) {
-            long secondsRemaining = locked.getEpochSecond() - Instant.now().getEpochSecond();
+        LockableAccount account = findAccount(email).orElse(null);
+        if (account == null) return;
+
+        if (isLockActive(account.getLockedUntil())) {
+            long secondsRemaining = secondsUntil(account.getLockedUntil());
             throw new AccountLockedException(formatLockoutMessage(secondsRemaining), secondsRemaining);
+        }
+
+        if (account.getLockedUntil() != null) {
+            account.clearLockExpiry();
+            account.save();
         }
     }
 
     /**
      * Belezi neuspesan pokusaj i lockuje racun ako je dosegnut prag.
-     *
-     * Spec Sc 5 (Bug T1-015): "posle 4 neuspeha, 5. pokusaj zakljucava nalog".
-     * Stari kod je samo postavljao lock na 5. pokusaju ali vracao genericku
-     * gresku "Invalid email or password" — korisnik je dobijao lockout alert
-     * tek na 6. pokusaju kad je {@code assertNotLocked} pucao. Sad bacamo
-     * {@link AccountLockedException} odmah kad pretreknemo prag, tako da
-     * korisnik vidi lockout poruku na samom 5. pokusaju.
      */
+    @Transactional(propagation = Propagation.REQUIRES_NEW, noRollbackFor = AccountLockedException.class)
     public void recordFailure(String email) {
         if (email == null) return;
-        String key = normalize(email);
-        AtomicInteger count = failedAttempts.get(key, k -> new AtomicInteger(0));
-        int attempts = count.incrementAndGet();
-        if (attempts >= maxFailedAttempts) {
-            Instant lockUntil = Instant.now().plus(Duration.ofMinutes(lockDurationMinutes));
-            lockedUntil.put(key, lockUntil);
-            failedAttempts.invalidate(key);
-            log.warn("Account locked: {} ({} failed attempts)", key, attempts);
-            long secondsRemaining = lockUntil.getEpochSecond() - Instant.now().getEpochSecond();
+        LockableAccount account = findAccount(email).orElse(null);
+        if (account == null) return;
+
+        if (isLockActive(account.getLockedUntil())) {
+            long secondsRemaining = secondsUntil(account.getLockedUntil());
             throw new AccountLockedException(formatLockoutMessage(secondsRemaining), secondsRemaining);
         }
+
+        int attempts = account.getFailedAttempts() + 1;
+        account.setFailedAttempts(attempts);
+
+        if (attempts >= maxFailedAttempts) {
+            LocalDateTime lockUntil = LocalDateTime.now().plusMinutes(lockDurationMinutes);
+            account.setLockedUntil(lockUntil);
+            account.save();
+            log.warn("Account locked: {} ({} failed attempts)", normalize(email), attempts);
+            try {
+                mailSenderService.sendAccountLockedMail(account.getEmail(), lockDurationMinutes);
+            } catch (Exception e) {
+                log.error("Failed to send account locked email to {}", account.getEmail(), e);
+            }
+            long secondsRemaining = secondsUntil(lockUntil);
+            throw new AccountLockedException(formatLockoutMessage(secondsRemaining), secondsRemaining);
+        }
+
+        account.save();
+    }
+
+    /**
+     * Resetuje brojac i otkljucava nalog (po uspesnom login-u ili resetu lozinke).
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void recordSuccess(String email) {
+        if (email == null) return;
+        LockableAccount account = findAccount(email).orElse(null);
+        if (account == null) return;
+
+        account.setFailedAttempts(0);
+        account.setLockedUntil(null);
+        account.save();
+    }
+
+    /** Vraca trenutni broj neuspesnih pokusaja; 0 ako nalog ne postoji. */
+    @Transactional(readOnly = true)
+    public int getFailureCount(String email) {
+        if (email == null) return 0;
+        return findAccount(email)
+                .map(LockableAccount::getFailedAttempts)
+                .orElse(0);
+    }
+
+    /** Vraca true ako je email trenutno lock-ovan. */
+    @Transactional(readOnly = true)
+    public boolean isLocked(String email) {
+        if (email == null) return false;
+        return findAccount(email)
+                .map(a -> isLockActive(a.getLockedUntil()))
+                .orElse(false);
+    }
+
+    private Optional<LockableAccount> findAccount(String email) {
+        String normalized = normalize(email);
+        Optional<Employee> employee = employeeRepository.findByEmail(normalized);
+        if (employee.isEmpty()) {
+            employee = employeeRepository.findByEmail(email.trim());
+        }
+        if (employee.isPresent()) {
+            return Optional.of(new EmployeeLockable(employee.get(), employeeRepository));
+        }
+
+        Optional<User> user = userRepository.findByEmail(normalized);
+        if (user.isEmpty()) {
+            user = userRepository.findByEmail(email.trim());
+        }
+        return user.map(u -> new UserLockable(u, userRepository));
+    }
+
+    private boolean isLockActive(LocalDateTime lockedUntil) {
+        return lockedUntil != null && lockedUntil.isAfter(LocalDateTime.now());
+    }
+
+    private long secondsUntil(LocalDateTime lockedUntil) {
+        return Duration.between(LocalDateTime.now(), lockedUntil).getSeconds();
     }
 
     private String formatLockoutMessage(long secondsRemaining) {
-        long minutes = Math.max(1, secondsRemaining / 60 + 1);
+        long minutes = Math.max(1, secondsRemaining / 60 + (secondsRemaining % 60 > 0 ? 1 : 0));
         return "Nalog je privremeno zakljucan zbog previse neuspesnih pokusaja. "
                 + "Pokusajte ponovo za " + minutes + " min.";
     }
 
-    /**
-     * Resetuje brojac (po uspesnom login-u).
-     */
-    public void recordSuccess(String email) {
-        if (email == null) return;
-        String key = normalize(email);
-        failedAttempts.invalidate(key);
-        // Lock se zadrzava ako je vec aktivan — ne unlock-ujemo eksplicitno;
-        // korisnik ce moci tek posle isteka.
-    }
-
-    /** Vraca trenutni broj neuspesa za email; 0 ako nema upisa. */
-    public int getFailureCount(String email) {
-        if (email == null) return 0;
-        AtomicInteger count = failedAttempts.getIfPresent(normalize(email));
-        return count != null ? count.get() : 0;
-    }
-
-    /** Vraca true ako je email trenutno lock-ovan. */
-    public boolean isLocked(String email) {
-        if (email == null) return false;
-        Instant locked = lockedUntil.getIfPresent(normalize(email));
-        return locked != null && locked.isAfter(Instant.now());
-    }
-
     private String normalize(String email) {
         return email.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private interface LockableAccount {
+        String getEmail();
+        int getFailedAttempts();
+        void setFailedAttempts(int attempts);
+        LocalDateTime getLockedUntil();
+        void setLockedUntil(LocalDateTime until);
+        void clearLockExpiry();
+        void save();
+    }
+
+    private static final class UserLockable implements LockableAccount {
+        private final User user;
+        private final UserRepository repository;
+
+        UserLockable(User user, UserRepository repository) {
+            this.user = user;
+            this.repository = repository;
+        }
+
+        @Override
+        public String getEmail() {
+            return user.getEmail();
+        }
+
+        @Override
+        public int getFailedAttempts() {
+            return user.getFailedLoginAttempts() != null ? user.getFailedLoginAttempts() : 0;
+        }
+
+        @Override
+        public void setFailedAttempts(int attempts) {
+            user.setFailedLoginAttempts(attempts);
+        }
+
+        @Override
+        public LocalDateTime getLockedUntil() {
+            return user.getAccountLockedUntil();
+        }
+
+        @Override
+        public void setLockedUntil(LocalDateTime until) {
+            user.setAccountLockedUntil(until);
+        }
+
+        @Override
+        public void clearLockExpiry() {
+            user.setAccountLockedUntil(null);
+        }
+
+        @Override
+        public void save() {
+            repository.save(user);
+        }
+    }
+
+    private static final class EmployeeLockable implements LockableAccount {
+        private final Employee employee;
+        private final EmployeeRepository repository;
+
+        EmployeeLockable(Employee employee, EmployeeRepository repository) {
+            this.employee = employee;
+            this.repository = repository;
+        }
+
+        @Override
+        public String getEmail() {
+            return employee.getEmail();
+        }
+
+        @Override
+        public int getFailedAttempts() {
+            return employee.getFailedLoginAttempts() != null ? employee.getFailedLoginAttempts() : 0;
+        }
+
+        @Override
+        public void setFailedAttempts(int attempts) {
+            employee.setFailedLoginAttempts(attempts);
+        }
+
+        @Override
+        public LocalDateTime getLockedUntil() {
+            return employee.getAccountLockedUntil();
+        }
+
+        @Override
+        public void setLockedUntil(LocalDateTime until) {
+            employee.setAccountLockedUntil(until);
+        }
+
+        @Override
+        public void clearLockExpiry() {
+            employee.setAccountLockedUntil(null);
+        }
+
+        @Override
+        public void save() {
+            repository.save(employee);
+        }
     }
 
     /**

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/auth/service/AuthService.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/auth/service/AuthService.java
@@ -47,37 +47,6 @@ public class AuthService {
     private final ApplicationEventPublisher eventPublisher;
     private final AccountLockoutService accountLockoutService;
 
-    /*
-     * // TODO [B2 - Validacija + brute-force | Nosilac: Andjela Vilcek]
-     *
-     * Nakon migracije AccountLockoutService na DB-bazirano stanje
-     * (videti TODO u AccountLockoutService.java), potrebne su sledece
-     * izmene u ovom servisu:
-     *
-     * 1. login() metoda:
-     *    - Redosled provera ostaje isti: najpre accountLockoutService.assertNotLocked,
-     *      zatim provera lozinke.
-     *    - Nakon sto AccountLockoutService pocne da cita accountLockedUntil
-     *      iz baze, assertNotLocked automatski postaje DB-svestan — login()
-     *      ne zahteva direktne izmene osim potencijalnog @Transactional
-     *      anotiranja ako se u istoj transakciji i cita i upisuje lockout stanje.
-     *    - Proveriti da li je @Transactional(readOnly = false) potreban na
-     *      login() da bi recordSuccess i recordFailure mogli da commituju.
-     *
-     * 2. resetPassword() metoda (linija ~272):
-     *    - Posle uspesne promene lozinke pozvati:
-     *        accountLockoutService.recordSuccess(targetEmail)
-     *      da se otkljuca nalog i nulira failedLoginAttempts u bazi.
-     *    - targetEmail je email korisnika cija je lozinka promenjena
-     *      (user.getEmail() ili employee.getEmail() — analogno sa
-     *      passwordResetToken.getUser()/getEmployee()).
-     *
-     * 3. Opciono — requestPasswordReset() metoda:
-     *    - Spec ne zahteva, ali je dobra praksa ne otkrivati da li email
-     *      postoji (trenutno baca RuntimeException ako korisnik ne postoji,
-     *      sto je security leak). Razmotriti silent no-op umesto exception-a.
-     */
-
     public AuthService(UserRepository userRepository,
                        EmployeeRepository employeeRepository,
                        ClientRepository clientRepository,
@@ -300,6 +269,7 @@ public class AuthService {
         return "Password reset token generated and email event emitted";
     }
 
+    @Transactional
     public String resetPassword(PasswordResetDto reset){
 
         PasswordResetToken passwordResetToken = passwordResetTokenRepository.findByToken(reset.getToken())
@@ -323,14 +293,22 @@ public class AuthService {
         if (user != null) {
             String hashedNewPassword = passwordEncoder.encode(reset.getNewPassword());
             user.setPassword(hashedNewPassword);
+            user.setFailedLoginAttempts(0);
+            user.setAccountLockedUntil(null);
             userRepository.save(user);
         } else {
             String salt = employee.getSaltPassword();
             employee.setPassword(passwordEncoder.encode(reset.getNewPassword() + salt));
+            employee.setFailedLoginAttempts(0);
+            employee.setAccountLockedUntil(null);
             employeeRepository.save(employee);
         }
         passwordResetToken.setUsed(true);
         passwordResetTokenRepository.save(passwordResetToken);
+
+        String targetEmail = user != null ? user.getEmail() : employee.getEmail();
+        accountLockoutService.recordSuccess(targetEmail);
+
         return "Password reset successfully!";
 
     }

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/auth/service/EmployeeUserDetails.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/auth/service/EmployeeUserDetails.java
@@ -5,6 +5,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import rs.raf.banka2_bek.employee.model.Employee;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -53,7 +54,8 @@ public class EmployeeUserDetails implements UserDetails {
 
     @Override
     public boolean isAccountNonLocked() {
-        return true;
+        LocalDateTime lockedUntil = employee.getAccountLockedUntil();
+        return lockedUntil == null || lockedUntil.isBefore(LocalDateTime.now());
     }
 
     @Override

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/employee/dto/CreateEmployeeRequestDto.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/employee/dto/CreateEmployeeRequestDto.java
@@ -3,6 +3,8 @@ package rs.raf.banka2_bek.employee.dto;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.Pattern;
 import lombok.Data;
 
 import java.time.LocalDate;
@@ -17,38 +19,8 @@ public class CreateEmployeeRequestDto {
     @NotBlank
     private String lastName;
 
-    /*
-     * // TODO [B2 - Validacija + brute-force | Nosilac: Andjela Vilcek]
-     *
-     * Dodati Jakarta Validation anotacije na polja dateOfBirth i phone:
-     *
-     * 1. Datum rodjenja — ne sme biti u buducnosti:
-     *    Polje je vec LocalDate (za razliku od RegisterRequestDto koji koristi Long),
-     *    sto omogucava direktnu upotrebu @Past:
-     *
-     *      @Past(message = "Datum rodjenja mora biti u proslosti")
-     *
-     *    Dodati @Past ispred ili ispod @NotNull anotacije.
-     *    Import: import jakarta.validation.constraints.Past;
-     *
-     * 2. Telefon — validacija formata:
-     *    Trenutno: samo @NotBlank, nema provere da su cifre.
-     *    Trebalo bi dodati @Pattern ispod @NotBlank:
-     *
-     *      @Pattern(
-     *          regexp = "^\\+?[0-9]{6,20}$",
-     *          message = "Telefon sme da sadrzi samo cifre uz opcioni vodeci znak +"
-     *      )
-     *
-     *    Import: import jakarta.validation.constraints.Pattern;
-     *    (import vec postoji ako je dodat za dateOfBirth — proveri).
-     *
-     * 3. Osigurati da odgovarajuci @RestController metod (CreateEmployee
-     *    endpoint u EmployeeController ili AdminController) ima @Valid
-     *    anotaciju na @RequestBody parametru, inace ove anotacije nemaju
-     *    efekta pri pozivu.
-     */
     @NotNull
+    @Past(message = "Datum rodjenja mora biti u proslosti")
     private LocalDate dateOfBirth;
 
     @NotBlank
@@ -59,6 +31,10 @@ public class CreateEmployeeRequestDto {
     private String email;
 
     @NotBlank
+    @Pattern(
+            regexp = "^\\+?[0-9]{6,20}$",
+            message = "Telefon sme da sadrzi samo cifre uz opcioni vodeci znak +"
+    )
     private String phone;
 
     @NotBlank

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/employee/model/Employee.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/employee/model/Employee.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -59,27 +60,13 @@ public class Employee {
     @Column(nullable = false)
     private Boolean active;
 
-    /*
-     * // TODO [B2 - Validacija + brute-force | Nosilac: Andjela Vilcek]
-     *
-     * Dodati sledeca dva polja radi DB-baziranog brute-force lockout-a
-     * (zamena za trenutnu Caffeine in-memory implementaciju u
-     * AccountLockoutService koja ne preziva restart i ne radi u
-     * multi-instance deploy-u):
-     *
-     *   @org.hibernate.annotations.ColumnDefault("0")
-     *   @Column(nullable = false)
-     *   private Integer failedLoginAttempts = 0;
-     *
-     *   @Column(nullable = true)
-     *   private java.time.LocalDateTime accountLockedUntil;
-     *
-     * Napomene:
-     * - Lombok @Builder/@Getter/@Setter automatski pokriju nova polja.
-     * - Hibernate ddl-auto=update automatski doda kolone pri sledecem startu.
-     * - Lockout logiku preseliti u AccountLockoutService.java;
-     *   videti TODO tamo za detalje.
-     */
+    @org.hibernate.annotations.ColumnDefault("0")
+    @Column(nullable = false)
+    @Builder.Default
+    private Integer failedLoginAttempts = 0;
+
+    @Column(nullable = true)
+    private LocalDateTime accountLockedUntil;
 
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "employee_permissions", joinColumns = @JoinColumn(name = "employee_id"))

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/notification/service/MailSenderService.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/notification/service/MailSenderService.java
@@ -5,6 +5,7 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 import rs.raf.banka2_bek.notification.event.InAppNotificationEvent;
 import rs.raf.banka2_bek.notification.template.AccountCreatedConfirmationEmailTemplate;
+import rs.raf.banka2_bek.notification.template.AccountLockedEmailTemplate;
 import rs.raf.banka2_bek.notification.template.ActivationConfirmedEmailTemplate;
 import rs.raf.banka2_bek.notification.template.ActivationEmailTemplate;
 import rs.raf.banka2_bek.notification.template.OtpEmailTemplate;
@@ -47,13 +48,6 @@ import java.time.LocalDate;
  *      loan, order, otc calls NotificationService.notify() on the relevant
  *      event — notify() takes care of everything else.
  *
- * ── TODO [B2 — Andjela Vilcek] ───────────────────────────────────────────
- *   Add sendAccountLockedMail(String toEmail, int lockMinutes, String resetLink)
- *   using a dedicated template (or extend TransactionEmailTemplate). The
- *   ACCOUNT_LOCKED type already has sendsEmail = true, so the generic email
- *   is currently sent; a dedicated template with the reset-password link
- *   improves user experience. The method is called from AccountLockoutService
- *   when the account is locked (after 5 failed login attempts).
  */
 @Service
 public class MailSenderService {
@@ -65,6 +59,7 @@ public class MailSenderService {
     private final String activationUrlBase;
     private final String activationPagePath;
     private final PasswordResetEmailTemplate passwordResetEmailTemplate;
+    private final AccountLockedEmailTemplate accountLockedEmailTemplate;
     private final ActivationEmailTemplate activationEmailTemplate;
     private final ActivationConfirmedEmailTemplate activationConfirmedEmailTemplate;
     private final AccountCreatedConfirmationEmailTemplate accountCreatedConfirmationEmailTemplate;
@@ -73,6 +68,7 @@ public class MailSenderService {
 
     public MailSenderService(JavaMailSender mailSender,
                              PasswordResetEmailTemplate passwordResetEmailTemplate,
+                             AccountLockedEmailTemplate accountLockedEmailTemplate,
                              ActivationEmailTemplate activationEmailTemplate,
                              ActivationConfirmedEmailTemplate activationConfirmedEmailTemplate,
                              AccountCreatedConfirmationEmailTemplate accountCreatedConfirmationEmailTemplate,
@@ -85,6 +81,7 @@ public class MailSenderService {
                              @Value("${notification.activation-page-path:/activate-account}") String activationPagePath) {
         this.mailSender = mailSender;
         this.passwordResetEmailTemplate = passwordResetEmailTemplate;
+        this.accountLockedEmailTemplate = accountLockedEmailTemplate;
         this.activationEmailTemplate = activationEmailTemplate;
         this.activationConfirmedEmailTemplate = activationConfirmedEmailTemplate;
         this.fromAddress = fromAddress;
@@ -102,6 +99,13 @@ public class MailSenderService {
         String subject = passwordResetEmailTemplate.buildSubject();
         String html = passwordResetEmailTemplate.buildBody(resetLink);
 
+        HtmlMailSender.sendHtmlMail(mailSender, fromAddress, toEmail, subject, html);
+    }
+
+    public void sendAccountLockedMail(String toEmail, int lockMinutes) {
+        String resetLink = passwordResetUrlBase + passwordResetPagePath;
+        String subject = accountLockedEmailTemplate.buildSubject();
+        String html = accountLockedEmailTemplate.buildBody(lockMinutes, resetLink);
         HtmlMailSender.sendHtmlMail(mailSender, fromAddress, toEmail, subject, html);
     }
 

--- a/banka2_bek/src/main/java/rs/raf/banka2_bek/notification/template/AccountLockedEmailTemplate.java
+++ b/banka2_bek/src/main/java/rs/raf/banka2_bek/notification/template/AccountLockedEmailTemplate.java
@@ -1,0 +1,77 @@
+package rs.raf.banka2_bek.notification.template;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class AccountLockedEmailTemplate {
+
+    public String buildSubject() {
+        return "Nalog privremeno zaključan – Banka 2";
+    }
+
+    public String buildBody(int lockMinutes, String resetLink) {
+        return """
+                <!DOCTYPE html>
+                <html lang="sr">
+                <head>
+                    <meta charset="UTF-8">
+                    <title>Nalog zaključan</title>
+                </head>
+                <body style="margin:0;padding:0;background-color:#f8fafc;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+                <table role="presentation" cellpadding="0" cellspacing="0" width="100%%" style="padding:32px 0;">
+                    <tr>
+                        <td align="center">
+                            <table role="presentation" cellpadding="0" cellspacing="0" width="100%%" style="max-width:520px;background-color:#ffffff;border-radius:16px;overflow:hidden;box-shadow:0 20px 50px rgba(99,102,241,0.18);border:1px solid #e5e7eb;">
+                                <tr>
+                                    <td style="background:linear-gradient(135deg,#6366f1,#7c3aed);padding:28px 24px;text-align:center;">
+                                        <p style="margin:0 0 4px 0;font-size:13px;font-weight:500;color:rgba(255,255,255,0.7);letter-spacing:0.08em;text-transform:uppercase;">Banka 2</p>
+                                        <h1 style="margin:0;font-size:22px;font-weight:700;color:#ffffff;">Nalog privremeno zaključan</h1>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td style="padding:32px 28px;text-align:center;">
+                                        <p style="margin:0 0 16px 0;font-size:15px;color:#374151;font-weight:600;">Zdravo,</p>
+                                        <p style="margin:0 0 16px 0;font-size:14px;color:#4b5563;line-height:1.6;">
+                                            Vaš nalog je privremeno zaključan zbog previše neuspešnih pokušaja prijave.
+                                            Prijava nije moguća narednih <strong>%d minuta</strong>.
+                                        </p>
+                                        <p style="margin:0 0 24px 0;font-size:13px;color:#6b7280;line-height:1.5;">
+                                            Ako ste zaboravili lozinku, možete je resetovati putem dugmeta ispod. Resetovanje lozinke
+                                            otključava nalog i omogućava ponovnu prijavu.
+                                        </p>
+                                        <table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 auto 28px auto;">
+                                            <tr>
+                                                <td style="border-radius:10px;background:linear-gradient(135deg,#6366f1,#7c3aed);">
+                                                    <a href="%s" style="display:inline-block;padding:14px 36px;color:#ffffff;text-decoration:none;font-size:14px;font-weight:600;letter-spacing:0.03em;">
+                                                        Resetujte lozinku
+                                                    </a>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                        <p style="margin:0 0 10px 0;font-size:12px;color:#9ca3af;">
+                                            Ako dugme ne radi, kopirajte i nalepite ovaj link u pretraživač:
+                                        </p>
+                                        <p style="margin:0 0 20px 0;font-size:12px;color:#6366f1;word-break:break-all;">
+                                            %s
+                                        </p>
+                                        <p style="margin:0;font-size:12px;color:#9ca3af;">
+                                            Ako niste pokušavali da se prijavite, kontaktirajte podršku.
+                                        </p>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td style="padding:16px 24px;border-top:1px solid #e5e7eb;background-color:#f9fafb;">
+                                        <p style="margin:0;font-size:11px;color:#9ca3af;text-align:center;">
+                                            Ovo je automatska poruka od Banka 2. Molimo ne odgovarajte na ovaj email.
+                                        </p>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                </table>
+                </body>
+                </html>
+                """.formatted(lockMinutes, resetLink, resetLink);
+    }
+}

--- a/banka2_bek/src/main/resources/application.properties
+++ b/banka2_bek/src/main/resources/application.properties
@@ -98,6 +98,10 @@ banka2.influx.enabled=${INFLUX_ENABLED:false}
 # nov secret, restartujemo BE — svi postojeci JWT-ovi se invalidiraju.
 jwt.secret=${JWT_SECRET:dev-only-jwt-secret-do-not-use-in-prod-rotate-via-env-var-on-each-deploy}
 
+# Account lockout (brute-force protection per email)
+auth.lockout.max-failed-attempts=5
+auth.lockout.lock-duration-minutes=10
+
 # OTP configuration
 otp.expiry-minutes=5
 otp.max-attempts=3

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/auth/controller/AuthLockoutIntegrationTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/auth/controller/AuthLockoutIntegrationTest.java
@@ -1,0 +1,204 @@
+package rs.raf.banka2_bek.auth.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+import rs.raf.banka2_bek.IntegrationTestCleanup;
+import rs.raf.banka2_bek.auth.model.PasswordResetToken;
+import rs.raf.banka2_bek.auth.model.User;
+import rs.raf.banka2_bek.auth.repository.PasswordResetTokenRepository;
+import rs.raf.banka2_bek.auth.repository.UserRepository;
+
+import javax.sql.DataSource;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class AuthLockoutIntegrationTest {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Value("${local.server.port}")
+    private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordResetTokenRepository passwordResetTokenRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private DataSource dataSource;
+
+    @BeforeEach
+    void cleanDatabase() {
+        IntegrationTestCleanup.truncateAllTables(dataSource);
+    }
+
+    private String url(String path) {
+        return "http://localhost:" + port + path;
+    }
+
+    private HttpEntity<String> loginBody(String email, String password) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        return new HttpEntity<>(
+                "{\"email\":\"" + email + "\",\"password\":\"" + password + "\"}",
+                headers
+        );
+    }
+
+    private void assertUnauthorizedLogin(String email, String password) {
+        assertThatThrownBy(() -> restTemplate.postForEntity(
+                url("/auth/login"), loginBody(email, password), String.class))
+                .isInstanceOf(HttpClientErrorException.Unauthorized.class);
+    }
+
+    private void assertLockedLoginResponse(String email, String password) {
+        assertThatThrownBy(() -> restTemplate.postForEntity(
+                url("/auth/login"), loginBody(email, password), String.class))
+                .isInstanceOf(HttpClientErrorException.Unauthorized.class)
+                .satisfies(ex -> {
+                    String body = ((HttpClientErrorException) ex).getResponseBodyAsString();
+                    if (body != null && !body.isBlank()) {
+                        assertThat(body).contains("Nalog je privremeno zakljucan");
+                    }
+                });
+
+        User user = userRepository.findByEmail(email).orElseThrow();
+        assertThat(user.getFailedLoginAttempts()).isEqualTo(5);
+        assertThat(user.getAccountLockedUntil()).isAfter(LocalDateTime.now());
+    }
+
+    @Test
+    void fiveFailedLogins_lockAccountAndRejectWhileLocked() {
+        User user = new User();
+        user.setEmail("lock@test.com");
+        user.setPassword(passwordEncoder.encode("CorrectPass12"));
+        user.setFirstName("Lock");
+        user.setLastName("Test");
+        user.setActive(true);
+        user.setFailedLoginAttempts(0);
+        userRepository.save(user);
+
+        for (int i = 0; i < 4; i++) {
+            assertUnauthorizedLogin("lock@test.com", "wrong");
+        }
+
+        assertLockedLoginResponse("lock@test.com", "wrong");
+
+        assertThatThrownBy(() -> restTemplate.postForEntity(
+                url("/auth/login"), loginBody("lock@test.com", "CorrectPass12"), String.class))
+                .isInstanceOf(HttpClientErrorException.Unauthorized.class);
+    }
+
+    @Test
+    void passwordReset_unlocksAccountAndAllowsLogin() {
+        User user = new User();
+        user.setEmail("unlock@test.com");
+        user.setPassword(passwordEncoder.encode("OldPass12"));
+        user.setFirstName("Unlock");
+        user.setLastName("Test");
+        user.setActive(true);
+        user.setFailedLoginAttempts(5);
+        user.setAccountLockedUntil(LocalDateTime.now().plusMinutes(10));
+        userRepository.save(user);
+
+        PasswordResetToken token = new PasswordResetToken();
+        token.setToken("unlock-token");
+        token.setUser(user);
+        token.setExpiresAt(LocalDateTime.now().plusMinutes(10));
+        token.setUsed(false);
+        passwordResetTokenRepository.save(token);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        ResponseEntity<String> resetResponse = restTemplate.postForEntity(
+                url("/auth/password_reset/confirm"),
+                new HttpEntity<>("{\"token\":\"unlock-token\",\"newPassword\":\"NewPass12\"}", headers),
+                String.class
+        );
+        assertThat(resetResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        User unlocked = userRepository.findByEmail("unlock@test.com").orElseThrow();
+        assertThat(unlocked.getFailedLoginAttempts()).isZero();
+        assertThat(unlocked.getAccountLockedUntil()).isNull();
+
+        ResponseEntity<String> loginResponse = restTemplate.postForEntity(
+                url("/auth/login"),
+                loginBody("unlock@test.com", "NewPass12"),
+                String.class
+        );
+        assertThat(loginResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(loginResponse.getBody()).contains("accessToken");
+    }
+
+    @Test
+    void fullFlow_failedLoginsLockAccountThenPasswordResetAllowsLogin() {
+        User user = new User();
+        user.setEmail("e2e@test.com");
+        user.setPassword(passwordEncoder.encode("OldPass12"));
+        user.setFirstName("E2E");
+        user.setLastName("Test");
+        user.setActive(true);
+        user.setFailedLoginAttempts(0);
+        userRepository.save(user);
+
+        for (int i = 0; i < 4; i++) {
+            assertUnauthorizedLogin("e2e@test.com", "wrong");
+        }
+
+        assertLockedLoginResponse("e2e@test.com", "wrong");
+
+        assertThatThrownBy(() -> restTemplate.postForEntity(
+                url("/auth/login"), loginBody("e2e@test.com", "OldPass12"), String.class))
+                .isInstanceOf(HttpClientErrorException.Unauthorized.class);
+
+        User locked = userRepository.findByEmail("e2e@test.com").orElseThrow();
+
+        PasswordResetToken token = new PasswordResetToken();
+        token.setToken("e2e-reset-token");
+        token.setUser(locked);
+        token.setExpiresAt(LocalDateTime.now().plusMinutes(10));
+        token.setUsed(false);
+        passwordResetTokenRepository.save(token);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        ResponseEntity<String> resetResponse = restTemplate.postForEntity(
+                url("/auth/password_reset/confirm"),
+                new HttpEntity<>("{\"token\":\"e2e-reset-token\",\"newPassword\":\"NewPass12\"}", headers),
+                String.class
+        );
+        assertThat(resetResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        User unlocked = userRepository.findByEmail("e2e@test.com").orElseThrow();
+        assertThat(unlocked.getFailedLoginAttempts()).isZero();
+        assertThat(unlocked.getAccountLockedUntil()).isNull();
+
+        ResponseEntity<String> loginResponse = restTemplate.postForEntity(
+                url("/auth/login"),
+                loginBody("e2e@test.com", "NewPass12"),
+                String.class
+        );
+        assertThat(loginResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(loginResponse.getBody()).contains("accessToken");
+    }
+}

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/auth/dto/DtoValidationTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/auth/dto/DtoValidationTest.java
@@ -181,6 +181,43 @@ class DtoValidationTest {
             Set<ConstraintViolation<RegisterRequestDto>> violations = validator.validate(dto);
             assertThat(violations).isNotEmpty();
         }
+
+        @Test
+        void invalidPhoneFormat_hasViolation() {
+            RegisterRequestDto dto = buildValid();
+            dto.setPhone("06-123-456");
+            Set<ConstraintViolation<RegisterRequestDto>> violations = validator.validate(dto);
+            assertThat(violations).isNotEmpty();
+            assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("phone"));
+        }
+
+        @Test
+        void validPhoneWithPlus_noViolation() {
+            RegisterRequestDto dto = buildValid();
+            dto.setPhone("+381601234567");
+            Set<ConstraintViolation<RegisterRequestDto>> violations = validator.validate(dto);
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        void futureDateOfBirth_hasViolation() {
+            RegisterRequestDto dto = buildValid();
+            dto.setDateOfBirth(System.currentTimeMillis() + 86_400_000L);
+            Set<ConstraintViolation<RegisterRequestDto>> violations = validator.validate(dto);
+            assertThat(violations).isNotEmpty();
+            assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("dateOfBirthValid"));
+        }
+
+        @Test
+        void pastDateOfBirth_noViolation() {
+            RegisterRequestDto dto = buildValid();
+            dto.setDateOfBirth(LocalDate.of(1990, 1, 1)
+                    .atStartOfDay(java.time.ZoneId.systemDefault())
+                    .toInstant()
+                    .toEpochMilli());
+            Set<ConstraintViolation<RegisterRequestDto>> violations = validator.validate(dto);
+            assertThat(violations).isEmpty();
+        }
     }
 
     // ── CreateEmployeeRequestDto ────────────────────────────────────
@@ -261,6 +298,32 @@ class DtoValidationTest {
         void nullPermissions_isOptional_noViolation() {
             CreateEmployeeRequestDto dto = buildValid();
             dto.setPermissions(null);
+            Set<ConstraintViolation<CreateEmployeeRequestDto>> violations = validator.validate(dto);
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        void futureDateOfBirth_hasViolation() {
+            CreateEmployeeRequestDto dto = buildValid();
+            dto.setDateOfBirth(LocalDate.now().plusDays(1));
+            Set<ConstraintViolation<CreateEmployeeRequestDto>> violations = validator.validate(dto);
+            assertThat(violations).isNotEmpty();
+            assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("dateOfBirth"));
+        }
+
+        @Test
+        void invalidPhoneFormat_hasViolation() {
+            CreateEmployeeRequestDto dto = buildValid();
+            dto.setPhone("abc-def");
+            Set<ConstraintViolation<CreateEmployeeRequestDto>> violations = validator.validate(dto);
+            assertThat(violations).isNotEmpty();
+            assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("phone"));
+        }
+
+        @Test
+        void validPhoneWithPlus_noViolation() {
+            CreateEmployeeRequestDto dto = buildValid();
+            dto.setPhone("+381601234567");
             Set<ConstraintViolation<CreateEmployeeRequestDto>> violations = validator.validate(dto);
             assertThat(violations).isEmpty();
         }

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/auth/service/AccountLockoutServiceTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/auth/service/AccountLockoutServiceTest.java
@@ -3,144 +3,200 @@ package rs.raf.banka2_bek.auth.service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.test.util.ReflectionTestUtils;
+import rs.raf.banka2_bek.auth.model.User;
+import rs.raf.banka2_bek.auth.repository.UserRepository;
+import rs.raf.banka2_bek.employee.model.Employee;
+import rs.raf.banka2_bek.employee.repository.EmployeeRepository;
+import rs.raf.banka2_bek.notification.service.MailSenderService;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@DisplayName("AccountLockoutService — failed attempts + lockout")
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("AccountLockoutService — DB lockout")
 class AccountLockoutServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private EmployeeRepository employeeRepository;
+
+    @Mock
+    private MailSenderService mailSenderService;
 
     private AccountLockoutService service;
 
+    private User user;
+
     @BeforeEach
     void setUp() {
-        service = new AccountLockoutService();
+        service = new AccountLockoutService(userRepository, employeeRepository, mailSenderService);
         ReflectionTestUtils.setField(service, "maxFailedAttempts", 5);
-        ReflectionTestUtils.setField(service, "lockDurationMinutes", 15);
-        ReflectionTestUtils.setField(service, "attemptWindowMinutes", 30);
-        service.init();
+        ReflectionTestUtils.setField(service, "lockDurationMinutes", 10);
+
+        user = new User();
+        user.setId(1L);
+        user.setEmail("alice@example.com");
+        user.setFailedLoginAttempts(0);
+        user.setAccountLockedUntil(null);
+
+        when(employeeRepository.findByEmail(any())).thenReturn(Optional.empty());
+        when(userRepository.findByEmail("alice@example.com")).thenReturn(Optional.of(user));
+        when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
     }
 
     @Test
-    @DisplayName("Novi email: failure count = 0, isLocked = false")
+    @DisplayName("Novi nalog: failure count = 0, isLocked = false")
     void freshEmail_zeroFailures() {
-        assertThat(service.getFailureCount("alice@example.com")).isEqualTo(0);
+        assertThat(service.getFailureCount("alice@example.com")).isZero();
         assertThat(service.isLocked("alice@example.com")).isFalse();
     }
 
     @Test
-    @DisplayName("recordFailure inkrementira brojac")
+    @DisplayName("recordFailure inkrementira brojac u bazi")
     void recordFailure_incrementsCount() {
         service.recordFailure("alice@example.com");
         service.recordFailure("alice@example.com");
 
-        assertThat(service.getFailureCount("alice@example.com")).isEqualTo(2);
+        assertThat(user.getFailedLoginAttempts()).isEqualTo(2);
+        verify(userRepository, org.mockito.Mockito.times(2)).save(user);
     }
 
     @Test
-    @DisplayName("Posle 5 neuspeha — racun je lock-ovan i 5. recordFailure baca AccountLockedException")
-    void fiveFailures_locksAccount() {
-        // Spec Sc 5 (Bug T1-015 12.05.2026): 5. neuspesni pokusaj sam baca
-        // AccountLockedException — korisnik vidi lockout poruku na 5. pokusaju,
-        // ne tek na 6. Prvih 4 pokusaja su tihi.
-        String email = "alice@example.com";
+    @DisplayName("Posle 5 neuspeha — racun je lock-ovan i salje se email")
+    void fiveFailures_locksAccountAndSendsEmail() {
         for (int i = 0; i < 4; i++) {
-            service.recordFailure(email);
+            service.recordFailure("alice@example.com");
         }
-        assertThat(service.isLocked(email)).isFalse();
+        assertThat(service.isLocked("alice@example.com")).isFalse();
 
-        assertThatThrownBy(() -> service.recordFailure(email))
+        assertThatThrownBy(() -> service.recordFailure("alice@example.com"))
                 .isInstanceOf(AccountLockoutService.AccountLockedException.class)
                 .hasMessageContaining("Nalog je privremeno zakljucan");
 
-        assertThat(service.isLocked(email)).isTrue();
+        assertThat(user.getFailedLoginAttempts()).isEqualTo(5);
+        assertThat(user.getAccountLockedUntil()).isAfter(LocalDateTime.now());
+        assertThat(service.isLocked("alice@example.com")).isTrue();
+        verify(mailSenderService).sendAccountLockedMail("alice@example.com", 10);
     }
 
     @Test
     @DisplayName("Lock se ne aktivira pre 5 neuspeha")
     void fourFailures_doesNotLock() {
-        String email = "alice@example.com";
         for (int i = 0; i < 4; i++) {
-            service.recordFailure(email);
+            service.recordFailure("alice@example.com");
         }
 
-        assertThat(service.isLocked(email)).isFalse();
+        assertThat(service.isLocked("alice@example.com")).isFalse();
+        assertThat(user.getAccountLockedUntil()).isNull();
+        verify(mailSenderService, never()).sendAccountLockedMail(any(), eq(10));
     }
 
     @Test
-    @DisplayName("recordSuccess resetuje brojac neuspeha")
-    void recordSuccess_resetsCount() {
-        String email = "alice@example.com";
-        service.recordFailure(email);
-        service.recordFailure(email);
-        assertThat(service.getFailureCount(email)).isEqualTo(2);
+    @DisplayName("recordSuccess resetuje brojac i otkljucava nalog")
+    void recordSuccess_resetsCountAndUnlocks() {
+        user.setFailedLoginAttempts(5);
+        user.setAccountLockedUntil(LocalDateTime.now().plusMinutes(10));
 
-        service.recordSuccess(email);
+        service.recordSuccess("alice@example.com");
 
-        assertThat(service.getFailureCount(email)).isEqualTo(0);
+        assertThat(user.getFailedLoginAttempts()).isZero();
+        assertThat(user.getAccountLockedUntil()).isNull();
+        verify(userRepository).save(user);
     }
 
     @Test
-    @DisplayName("assertNotLocked baca AccountLockedException kad je lock aktivan")
+    @DisplayName("assertNotLocked baca izuzetak kad je lock aktivan")
     void assertNotLocked_throwsWhenLocked() {
-        String email = "alice@example.com";
-        // Prvih 4 ne bacaju; 5. baca i postavlja lock. Hvatamo da nastavimo.
-        for (int i = 0; i < 4; i++) {
-            service.recordFailure(email);
-        }
-        try {
-            service.recordFailure(email);
-        } catch (AccountLockoutService.AccountLockedException expected) {
-            // ocekivano
-        }
+        user.setFailedLoginAttempts(5);
+        user.setAccountLockedUntil(LocalDateTime.now().plusMinutes(10));
 
-        assertThatThrownBy(() -> service.assertNotLocked(email))
+        assertThatThrownBy(() -> service.assertNotLocked("alice@example.com"))
                 .isInstanceOf(AccountLockoutService.AccountLockedException.class)
                 .hasMessageContaining("Nalog je privremeno zakljucan");
     }
 
     @Test
-    @DisplayName("assertNotLocked ne baca kad nije lock-ovan")
-    void assertNotLocked_noOpWhenNotLocked() {
+    @DisplayName("Istekao lock — assertNotLocked prolazi i cisti accountLockedUntil")
+    void assertNotLocked_allowsAfterLockExpired() {
+        user.setFailedLoginAttempts(5);
+        user.setAccountLockedUntil(LocalDateTime.now().minusMinutes(1));
+
         service.assertNotLocked("alice@example.com");
-        // Bez exception-a → pass
+
+        assertThat(user.getAccountLockedUntil()).isNull();
+        assertThat(service.isLocked("alice@example.com")).isFalse();
     }
 
     @Test
-    @DisplayName("Email je case-insensitive")
-    void emailNormalization() {
-        service.recordFailure("Alice@Example.com");
-        service.recordFailure("ALICE@example.COM");
+    @DisplayName("Ne postojeci email — no-op")
+    void unknownEmail_noOp() {
+        when(userRepository.findByEmail(any())).thenReturn(Optional.empty());
 
-        assertThat(service.getFailureCount("alice@example.com")).isEqualTo(2);
+        service.recordFailure("unknown@example.com");
+        service.recordSuccess("unknown@example.com");
+        service.assertNotLocked("unknown@example.com");
+
+        assertThat(service.getFailureCount("unknown@example.com")).isZero();
+        verify(userRepository, never()).save(any());
     }
 
     @Test
-    @DisplayName("Razliciti email-ovi se nezavisno broje")
-    void differentEmails_independent() {
-        // 5. neuspeh za alice baca exception — hvatamo da bismo nastavili sa bob.
-        for (int i = 0; i < 4; i++) service.recordFailure("alice@example.com");
-        try {
-            service.recordFailure("alice@example.com");
-        } catch (AccountLockoutService.AccountLockedException expected) {
-            // ok
+    @DisplayName("Zaposleni — lockout koristi Employee entitet")
+    void employeeAccount_lockout() {
+        Employee employee = Employee.builder()
+                .id(2L)
+                .email("emp@banka.rs")
+                .firstName("E")
+                .lastName("E")
+                .dateOfBirth(LocalDate.of(1990, 1, 1))
+                .gender("M")
+                .phone("0611111111")
+                .address("A")
+                .username("emp")
+                .password("hash")
+                .saltPassword("salt")
+                .position("Dev")
+                .department("IT")
+                .active(true)
+                .failedLoginAttempts(0)
+                .permissions(Set.of("ADMIN"))
+                .build();
+
+        when(employeeRepository.findByEmail("emp@banka.rs")).thenReturn(Optional.of(employee));
+        when(employeeRepository.save(any(Employee.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        for (int i = 0; i < 5; i++) {
+            try {
+                service.recordFailure("emp@banka.rs");
+            } catch (AccountLockoutService.AccountLockedException ignored) {
+                // poslednji pokusaj
+            }
         }
-        service.recordFailure("bob@example.com");
 
-        assertThat(service.isLocked("alice@example.com")).isTrue();
-        assertThat(service.isLocked("bob@example.com")).isFalse();
-        assertThat(service.getFailureCount("bob@example.com")).isEqualTo(1);
-    }
-
-    @Test
-    @DisplayName("Null email je no-op")
-    void nullEmail_noOp() {
-        service.recordFailure(null);
-        service.recordSuccess(null);
-        service.assertNotLocked(null);
-
-        assertThat(service.getFailureCount(null)).isEqualTo(0);
-        assertThat(service.isLocked(null)).isFalse();
+        ArgumentCaptor<Employee> captor = ArgumentCaptor.forClass(Employee.class);
+        verify(employeeRepository, org.mockito.Mockito.atLeastOnce()).save(captor.capture());
+        assertThat(employee.getFailedLoginAttempts()).isEqualTo(5);
+        assertThat(employee.getAccountLockedUntil()).isNotNull();
+        verify(mailSenderService).sendAccountLockedMail("emp@banka.rs", 10);
     }
 }

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/auth/service/AuthServiceTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/auth/service/AuthServiceTest.java
@@ -40,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -136,6 +137,20 @@ class AuthServiceTest {
 
         assertThat(response.getAccessToken()).isEqualTo("access");
         assertThat(response.getRefreshToken()).isEqualTo("refresh");
+    }
+
+    @Test
+    void loginRejectsWhenAccountLocked() {
+        doThrow(new AccountLockoutService.AccountLockedException(
+                "Nalog je privremeno zakljucan zbog previse neuspesnih pokusaja. Pokusajte ponovo za 10 min.",
+                600))
+                .when(accountLockoutService).assertNotLocked("user@test.com");
+
+        assertThatThrownBy(() -> authService.login(new LoginRequestDto("user@test.com", "password")))
+                .isInstanceOf(AccountLockoutService.AccountLockedException.class)
+                .hasMessageContaining("Nalog je privremeno zakljucan");
+
+        verify(accountLockoutService).assertNotLocked("user@test.com");
     }
 
     @Test
@@ -351,6 +366,7 @@ class AuthServiceTest {
         verify(userRepository).save(user);
         verify(passwordResetTokenRepository).save(token);
         assertThat(token.getUsed()).isTrue();
+        verify(accountLockoutService).recordSuccess("user@test.com");
     }
 
     // ===== Register with duplicate email error =====

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/notification/service/MailSenderServiceImplExtendedTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/notification/service/MailSenderServiceImplExtendedTest.java
@@ -28,6 +28,7 @@ class MailSenderServiceImplExtendedTest {
     @Mock private AccountCreatedConfirmationEmailTemplate accountCreatedConfirmationEmailTemplate;
     @Mock private OtpEmailTemplate otpEmailTemplate;
     @Mock private TransactionEmailTemplate transactionEmailTemplate;
+    @Mock private AccountLockedEmailTemplate accountLockedEmailTemplate;
     @Mock private MimeMessage mimeMessage;
 
     private MailSenderService service;
@@ -35,7 +36,7 @@ class MailSenderServiceImplExtendedTest {
     @BeforeEach
     void setUp() {
         when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
-        service = new MailSenderService(mailSender, passwordResetEmailTemplate, activationEmailTemplate,
+        service = new MailSenderService(mailSender, passwordResetEmailTemplate, accountLockedEmailTemplate, activationEmailTemplate,
                 activationConfirmedEmailTemplate, accountCreatedConfirmationEmailTemplate, otpEmailTemplate,
                 transactionEmailTemplate, "noreply@banka.rs", "http://localhost:3000", "/reset-password",
                 "http://localhost:3000", "/activate-account");

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/notification/service/MailSenderServiceImplTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/notification/service/MailSenderServiceImplTest.java
@@ -9,6 +9,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mail.javamail.JavaMailSender;
 import rs.raf.banka2_bek.notification.template.AccountCreatedConfirmationEmailTemplate;
+import rs.raf.banka2_bek.notification.template.AccountLockedEmailTemplate;
 import rs.raf.banka2_bek.notification.template.ActivationConfirmedEmailTemplate;
 import rs.raf.banka2_bek.notification.template.ActivationEmailTemplate;
 import rs.raf.banka2_bek.notification.template.OtpEmailTemplate;
@@ -18,6 +19,7 @@ import rs.raf.banka2_bek.notification.template.TransactionEmailTemplate;
 import java.util.Properties;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -39,6 +41,8 @@ class MailSenderServiceImplTest {
     private OtpEmailTemplate otpEmailTemplate;
     @Mock
     private TransactionEmailTemplate transactionEmailTemplate;
+    @Mock
+    private AccountLockedEmailTemplate accountLockedEmailTemplate;
 
     private MailSenderService service;
 
@@ -51,6 +55,7 @@ class MailSenderServiceImplTest {
         service = new MailSenderService(
                 mailSender,
                 passwordResetTemplate,
+                accountLockedEmailTemplate,
                 activationTemplate,
                 activationConfirmedTemplate,
                 accountCreatedConfirmationEmailTemplate,
@@ -62,6 +67,16 @@ class MailSenderServiceImplTest {
                 "http://localhost:3000",
                 "/activate-account"
         );
+    }
+
+    @Test
+    void sendAccountLockedMail_sends() {
+        when(accountLockedEmailTemplate.buildSubject()).thenReturn("Locked");
+        when(accountLockedEmailTemplate.buildBody(anyInt(), anyString())).thenReturn("<html/>");
+
+        service.sendAccountLockedMail("user@test.com", 10);
+
+        verify(mailSender).send(any(MimeMessage.class));
     }
 
     @Test

--- a/banka2_bek/src/test/java/rs/raf/banka2_bek/notification/service/MailSenderServiceInAppNotificationTest.java
+++ b/banka2_bek/src/test/java/rs/raf/banka2_bek/notification/service/MailSenderServiceInAppNotificationTest.java
@@ -11,6 +11,7 @@ import org.springframework.mail.javamail.JavaMailSender;
 import rs.raf.banka2_bek.notification.event.InAppNotificationEvent;
 import rs.raf.banka2_bek.notification.model.NotificationType;
 import rs.raf.banka2_bek.notification.template.AccountCreatedConfirmationEmailTemplate;
+import rs.raf.banka2_bek.notification.template.AccountLockedEmailTemplate;
 import rs.raf.banka2_bek.notification.template.ActivationConfirmedEmailTemplate;
 import rs.raf.banka2_bek.notification.template.ActivationEmailTemplate;
 import rs.raf.banka2_bek.notification.template.OtpEmailTemplate;
@@ -35,6 +36,7 @@ class MailSenderServiceInAppNotificationTest {
     @Mock private AccountCreatedConfirmationEmailTemplate accountCreatedConfirmationEmailTemplate;
     @Mock private OtpEmailTemplate otpEmailTemplate;
     @Mock private TransactionEmailTemplate transactionEmailTemplate;
+    @Mock private AccountLockedEmailTemplate accountLockedEmailTemplate;
 
     private JavaMailSender mailSender;
     private MimeMessage realMessage;
@@ -47,7 +49,7 @@ class MailSenderServiceInAppNotificationTest {
         when(mailSender.createMimeMessage()).thenReturn(realMessage);
 
         service = new MailSenderService(mailSender,
-                passwordResetEmailTemplate, activationEmailTemplate,
+                passwordResetEmailTemplate, accountLockedEmailTemplate, activationEmailTemplate,
                 activationConfirmedEmailTemplate, accountCreatedConfirmationEmailTemplate,
                 otpEmailTemplate, transactionEmailTemplate,
                 "from@test.com", "http://localhost", "/reset",

--- a/banka2_bek/src/test/resources/application-test.properties
+++ b/banka2_bek/src/test/resources/application-test.properties
@@ -37,6 +37,9 @@ interbank.partners[0].inbound-token=test-key-dummy
 # u testovima mu omogucava da se ponasa kao "off" bez specijalnog disabling-a.
 auth.rate-limit.capacity=100000
 
+auth.lockout.max-failed-attempts=5
+auth.lockout.lock-duration-minutes=10
+
 # JWT secret za testove (dovoljno dugacak za HS256 — minimum 32 bajta).
 # Production setuje preko ${JWT_SECRET}.
 jwt.secret=test-jwt-secret-do-not-use-in-prod-32-bytes-minimum-required-for-hs256


### PR DESCRIPTION
## Summary

Implementacija zadatka B2 (Celina 1): pojačana validacija podataka pri registraciji korisnika i kreiranju zaposlenog, i prelazak brute-force zaštite sa in-memory keša na trajno stanje u bazi.

## Validacija unosa

- **RegisterRequestDto**: `@Pattern` za telefon (samo cifre, opcioni `+`), `@AssertTrue` za datum rođenja (ne sme biti u budućnosti)
- **CreateEmployeeRequestDto**: `@Pattern` za telefon, `@Past` za datum rođenja
- Email format već postoji preko `@Email`; jedinstvenost ostaje na servisnom nivou

## Brute-force zaštita

- Dodata polja `failedLoginAttempts` i `accountLockedUntil` na entitete `User` i `Employee`
- `AccountLockoutService` preradjen sa Caffeine keša na DB (User/Employee repozitorijumi)
- Posle 5 neuspešnih pokušaja prijave nalog se zaključava na **10 minuta**
- Tokom lock-a prijava se odbija sa jasnom porukom (401)
- Pri zaključavanju šalje se email sa linkom za reset lozinke (`AccountLockedEmailTemplate`, `sendAccountLockedMail`)
- Uspešna prijava resetuje brojač; reset lozinke otključava nalog i nulira brojač
- `AuthService.resetPassword()` ažurira lockout polja na entitetu da se izbegne prepisivanje pri commit-u transakcije

## Testiranje

- Unit: `AccountLockoutServiceTest`, `DtoValidationTest`, `AuthServiceTest` (login tokom lock-a)
- Integracioni: `AuthLockoutIntegrationTest` (prijava → lock → reset → ponovna prijava)

## Konfiguracija

- `auth.lockout.max-failed-attempts=5`
- `auth.lockout.lock-duration-minutes=10`